### PR TITLE
Bump version of @io_bazel_rules_docker

### DIFF
--- a/distribution/docker/deps.bzl
+++ b/distribution/docker/deps.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps():
     http_archive(
         name = "io_bazel_rules_docker",
-        sha256 = "8987c47e480a6ec7628a99159dc5da8d4a9b5367b31ac3aaecbee954ee37f75c",
-        strip_prefix = "rules_docker-9d5735a1da710a645b2863f9ebba58bba51ad09c",
-        urls = ["https://github.com/vaticle/rules_docker/archive/9d5735a1da710a645b2863f9ebba58bba51ad09c.tar.gz"],
+        sha256 = "e9d5e14a8021f1f29981b92d189c1b10715f6d77179ade89dc658f7363701cc6",
+        strip_prefix = "rules_docker-20c0025d44671df55c0b7bfc0ad649c740655185",
+        urls = ["https://github.com/vaticle/rules_docker/archive/20c0025d44671df55c0b7bfc0ad649c740655185.tar.gz"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Propogate the bugfix in `rules_pkg` via `rules_docker`

## What are the changes implemented in this PR?

Upgrade `rules_docker` to our forked version with all the needed changes (`vaticle` branch)