### PR TITLE
Bump pygithub to 1.55

### DIFF
--- a/tool/requirements.txt
+++ b/tool/requirements.txt
@@ -1,4 +1,4 @@
-PyGithub==1.43.2
+PyGithub==1.55
 urllib3==1.24.2
 chardet==3.0.4
 idna==2.7


### PR DESCRIPTION
## What is the goal of this PR?
To fix deployment issues, we have to bump PyGithub to 1.55

## What are the changes implemented in this PR?
Use lates pygithub relesae