### PR TITLE
Guava 30.1 needs to use 30.1-jre version

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -25,7 +25,7 @@ artifacts = {
     "com.google.code.findbugs:jsr305": "2.0.2",
     "com.google.code.gson:gson": "2.8.5",
     "com.google.errorprone:error_prone_annotations": "2.4.0",
-    "com.google.guava:guava-jre": "30.1",
+    "com.google.guava:guava": "30.1-jre",
     "com.google.http-client:google-http-client": "1.34.2",
     "com.google.inject:guice": "4.2.2",
     "com.google.ortools:ortools-darwin": "8.0.8283",

--- a/library/maven/update.kt
+++ b/library/maven/update.kt
@@ -17,6 +17,7 @@ fun main() {
     val snapshotNew = snapshotUpdateProc.inputStream
             .use { inStr -> inStr.reader().readLines() }
             .toSortedSet()
+    println(snapshotNew)
     write(snapshotFile, (snapshotNew.joinToString(lineSeparator()) + lineSeparator()).toByteArray())
     if (snapshotUpdateProc.exitValue() != 0) {
         throw RuntimeException("'$snapshotCommand' failed with exit code '${snapshotUpdateProc.exitValue()}'")

--- a/library/maven/update.kt
+++ b/library/maven/update.kt
@@ -17,7 +17,6 @@ fun main() {
     val snapshotNew = snapshotUpdateProc.inputStream
             .use { inStr -> inStr.reader().readLines() }
             .toSortedSet()
-    println(snapshotNew)
     write(snapshotFile, (snapshotNew.joinToString(lineSeparator()) + lineSeparator()).toByteArray())
     if (snapshotUpdateProc.exitValue() != 0) {
         throw RuntimeException("'$snapshotCommand' failed with exit code '${snapshotUpdateProc.exitValue()}'")

--- a/tool/checkstyle/deps.bzl
+++ b/tool/checkstyle/deps.bzl
@@ -27,7 +27,7 @@ def deps(
       "commons_beanutils_commons_beanutils": "1.9.3",
       "info_picocli_picocli": "3.8.2",
       "commons_collections_commons_collections": "3.2.2",
-      "com_google_guava_guava23": "23.0",
+      "com_google_guava_guava30jre": "30.1",
       "org_slf4j_slf4j_api": "1.7.7",
       "org_slf4j_slf4j_jcl": "1.7.7",
     }
@@ -80,11 +80,11 @@ def deps(
         server_urls = ["https://repo1.maven.org/maven2/"],
         licenses = ["notice"],
     )
-  if not "com_google_guava_guava23" in omit:
+  if not "com_google_guava_guava30jre" in omit:
     jvm_maven_import_external(
-        name = "com_google_guava_guava23",
-        artifact = "com.google.guava:guava:" + versions["com_google_guava_guava23"],
-        artifact_sha256 = "7baa80df284117e5b945b19b98d367a85ea7b7801bd358ff657946c3bd1b6596",
+        name = "com_google_guava_guava30jre",
+        artifact = "com.google.guava:guava:" + versions["com_google_guava_guava30jre"],
+        artifact_sha256 = "e6dd072f9d3fe02a4600688380bd422bdac184caf6fe2418cfdd0934f09432aa",
         server_urls = ["https://repo1.maven.org/maven2/"],
         licenses = ["notice"],
     )

--- a/tool/checkstyle/deps.bzl
+++ b/tool/checkstyle/deps.bzl
@@ -27,7 +27,7 @@ def deps(
       "commons_beanutils_commons_beanutils": "1.9.3",
       "info_picocli_picocli": "3.8.2",
       "commons_collections_commons_collections": "3.2.2",
-      "com_google_guava_guava30jre": "30.1",
+      "com_google_guava_guava30jre": "30.1-jre",
       "org_slf4j_slf4j_api": "1.7.7",
       "org_slf4j_slf4j_jcl": "1.7.7",
     }

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -136,7 +136,7 @@ checkstyle_test = rule(
             Label("@org_slf4j_slf4j_jcl//jar"),
             Label("@antlr_antlr//jar"),
             Label("@org_antlr_antlr4_runtime//jar"),
-            Label("@com_google_guava_guava23//jar"),
+#            Label("@com_google_guava_guava23//jar"),
         ]),
         "_license_files": attr.label_list(
             allow_files=True,

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -136,7 +136,7 @@ checkstyle_test = rule(
             Label("@org_slf4j_slf4j_jcl//jar"),
             Label("@antlr_antlr//jar"),
             Label("@org_antlr_antlr4_runtime//jar"),
-#            Label("@com_google_guava_guava23//jar"),
+            Label("@com_google_guava_guava30jre//jar"),
         ]),
         "_license_files": attr.label_list(
             allow_files=True,


### PR DESCRIPTION
## What is the goal of this PR?

Previously in #295 we used the wrong way to import Guava 30.1, we correctly use 30.1-jre insted of guava-jre with version 30.1

## What are the changes implemented in this PR?

* Update to version 30.1 correctly
* regenerate the sha256 for the checkstyle dependency, which also uses version 30-jre instead of the old version 23
