### PR TITLE
Set up self-hosted ELK stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ bazel-out
 bazel-dependencies
 bazel-testlogs
 tool/bazelcache/.terraform/*
+tool/elk/.terraform/*
+tool/elk/*.tfvars
+tool/elk/.terraform.lock.hcl

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,5 +72,8 @@ rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
+load("@vaticle_bazel_distribution//packer:deps.bzl", deploy_packer_dependencies="deps")
+deploy_packer_dependencies()
+
 # Load Maven artifacts
 maven(vaticle_dependencies_tool_maven_artifacts)

--- a/tool/elk/images/BUILD
+++ b/tool/elk/images/BUILD
@@ -1,0 +1,19 @@
+load("@vaticle_bazel_distribution//packer:rules.bzl", "deploy_packer")
+load("@vaticle_bazel_distribution//gcp:rules.bzl", "assemble_gcp")
+
+assemble_gcp(
+    name = "assemble-gcp-elk",
+    install = "//tool/elk/images:install-elk.sh",
+    project_id = "vaticle-factory-prod",
+    disable_default_service_account = True,
+    image_name = "elk-{{user `version`}}",
+    source_image_family = "ubuntu-2004-lts",
+    image_family = "web",
+    zone = "europe-west2-b"
+)
+
+deploy_packer(
+    name = "deploy-gcp-elk",
+    target = ":assemble-gcp-elk",
+)
+

--- a/tool/elk/images/install-elk.sh
+++ b/tool/elk/images/install-elk.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -ex
+
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+sudo apt-get install apt-transport-https
+echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-7.x.list
+sudo apt-get update && sudo apt-get install elasticsearch kibana
+
+sudo systemctl daemon-reload
+
+es_config=$(mktemp)
+cat > $es_config << EOF
+node.name: logging.vaticle.com
+path.data: /var/lib/elasticsearch
+path.logs: /var/log/elasticsearch
+network.host: 0.0.0.0
+discovery.type: single-node
+http.port: 2053
+xpack.security.enabled: true
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.key: /etc/elasticsearch/key.pem
+xpack.security.http.ssl.certificate: /etc/elasticsearch/cert.pem
+EOF
+
+
+kibana_config=$(mktemp)
+cat > $kibana_config << EOF
+server.port: 443
+server.host: "0.0.0.0"
+server.name: "logging.vaticle.com"
+elasticsearch.hosts: ["https://logging.vaticle.com:2053"]
+server.ssl.enabled: true
+server.ssl.certificate: /etc/elasticsearch/cert.pem
+server.ssl.key: /etc/elasticsearch/key.pem
+elasticsearch.username: "kibana_system"
+server.publicBaseUrl: "https://logging.vaticle.com"
+EOF
+
+sudo mv $es_config /etc/elasticsearch/elasticsearch.yml
+sudo chown root:elasticsearch /etc/elasticsearch/elasticsearch.yml
+sudo chmod u+rw,g+rw /etc/elasticsearch/elasticsearch.yml
+
+sudo mv $kibana_config /etc/kibana/kibana.yml
+sudo chown root:kibana /etc/kibana/kibana.yml
+sudo chmod u+rw,g+rw /etc/kibana/kibana.yml
+
+sudo setcap cap_net_bind_service=+epi /usr/share/kibana/bin/kibana
+sudo setcap cap_net_bind_service=+epi /usr/share/kibana/bin/kibana-plugin
+sudo setcap cap_net_bind_service=+epi /usr/share/kibana/bin/kibana-keystore
+sudo setcap cap_net_bind_service=+epi /usr/share/kibana/node/bin/node

--- a/tool/elk/main.tf
+++ b/tool/elk/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  backend "gcs" {
+    bucket  = "vaticle-factory-prod-terraform-state"
+    prefix  = "terraform/elk"
+  }
+}
+
+provider "google" {
+  project = "vaticle-factory-prod"
+  region  = "europe-west2"
+  zone    = "europe-west2-b"
+}
+
+resource "google_compute_firewall" "elk_api_firewall" {
+  name    = "elk-api-firewall"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443", "2053"]
+  }
+
+  target_tags = ["elk"]
+}
+
+resource "google_compute_address" "elk_static_ip" {
+  name = "elk-static-ip"
+}
+
+resource "google_compute_disk" "elk_additional" {
+  name  = "elk-additional"
+  type  = "pd-ssd"
+}
+
+resource "google_compute_instance" "elk" {
+  name                      = "elk"
+  machine_type              = "n1-standard-2"
+
+  boot_disk {
+    initialize_params {
+      image = "vaticle-factory-prod/elk-v1"
+    }
+    device_name = "boot"
+  }
+
+  attached_disk {
+    source = google_compute_disk.elk_additional.name
+    device_name = "elk-additional"
+  }
+
+  service_account {
+    email = "elk-account@vaticle-factory-prod.iam.gserviceaccount.com"
+    scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      nat_ip = google_compute_address.elk_static_ip.address
+    }
+  }
+
+  tags = ["elk"]
+
+  metadata_startup_script = file("${path.module}/startup/startup-elk.sh")
+}
+
+
+resource "google_secret_manager_secret" "certificate" {
+  secret_id = "certificate"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "certificate_version" {
+  secret      = google_secret_manager_secret.certificate.id
+  secret_data = var.secrets.certificate
+}
+
+
+resource "google_secret_manager_secret" "key" {
+  secret_id = "key"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "key_version" {
+  secret      = google_secret_manager_secret.key.id
+  secret_data = var.secrets.key
+}

--- a/tool/elk/startup/startup-elk.sh
+++ b/tool/elk/startup/startup-elk.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+sudo gcloud secrets versions access latest --secret certificate | base64 -d | sudo tee /etc/elasticsearch/cert.pem
+sudo gcloud secrets versions access latest --secret key | base64 -d | sudo tee /etc/elasticsearch/key.pem
+
+sudo chmod a+r /etc/elasticsearch/cert.pem
+sudo chmod a+r /etc/elasticsearch/key.pem
+sudo chmod a+x /etc/elasticsearch/
+
+
+sudo systemctl start elasticsearch
+
+ES_PASSWORDS_FILE="/etc/elasticsearch/es-passwords.txt"
+
+if [ ! -f $ES_PASSWORDS_FILE ]; then
+  sudo /usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto -u "https://logging.vaticle.com:2053" --batch | sudo tee $ES_PASSWORDS_FILE
+  KIBANA_SYSTEM_PASSWORD=$(sudo awk '/PASSWORD kibana_system/ { print $4 }' $ES_PASSWORDS_FILE)
+  echo "elasticsearch.password: \"$KIBANA_SYSTEM_PASSWORD\"" | sudo tee -a /etc/kibana/kibana.yml
+fi
+
+sudo systemctl start kibana

--- a/tool/elk/variables.tf
+++ b/tool/elk/variables.tf
@@ -1,0 +1,3 @@
+variable "secrets" {
+  description = "Secret values for ELK"
+}


### PR DESCRIPTION
## What is the goal of this PR?

Set up ELK on GCP for logging Grabl and TypeDB Cluster

## What are the changes implemented in this PR?

Fix #298

* New target for deploying ELK image on GCP: `//tool/elk/images:deploy-gcp-elk`
* New Terraform definitions for the ELK stack are stored in `tool/elk/*.tf` and include a VM running ElasticSearch and Kibana; static IP; secrets for storing certificate/private key for SSL.