### PR TITLE
Bump versions of Azure Storage Maven libraries

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -5,8 +5,8 @@ artifacts = {
     "com.auth0:java-jwt": "3.8.3",
     "com.azure:azure-core": "1.5.0",
     "com.azure:azure-identity": "1.0.6",
-    "com.azure:azure-storage-blob": "12.6.0",
-    "com.azure:azure-storage-common": "12.6.0",
+    "com.azure:azure-storage-blob": "12.7.0",
+    "com.azure:azure-storage-common": "12.7.0",
     "com.datastax.oss:java-driver-core": {
         "exclude": ["com.github.jnr:jnr-ffi"],
         "version": "4.3.0",


### PR DESCRIPTION
## What is the goal of this PR?

Unblock Grabl builds by using a version of Maven libraries can be downloaded.

## What are the changes implemented in this PR?

For the unknown reason, Grabl builds now fail with this error:

```
ERROR: Error fetching repository: Traceback (most recent call last):
	File "/home/circleci/.cache/bazel/_bazel_circleci/a22eaad070d73c89945f8e63b8f1272e/external/rules_jvm_external/coursier.bzl", line 544, column 13, in _coursier_fetch_impl
		fail("Error while fetching artifact with coursier: " + exec_result.stderr)
Error in fail: Error while fetching artifact with coursier: Resolution error: Error downloading com.azure:azure-storage-blob:12.6.0
```

After some investigation, it looks like there's an open issue for fixing it upstream: Azure/azure-sdk-for-java#23616
In order to unblock our builds, we upgrade by one minor version which **is** available on Maven Central.