### PR TITLE
Update //library/crates

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "a06fbd4e30a7f7fe7c5eea64fd16632acd95fa0b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "fba26ee50093dc8070b6427c70257e0f76313a9a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )

--- a/library/crates/remote/BUILD.antlr-rust-0.2.0.bazel
+++ b/library/crates/remote/BUILD.antlr-rust-0.2.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=antlr-rust"
     ],
     version = "0.2.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.better_any-0.1.1.bazel
+++ b/library/crates/remote/BUILD.better_any-0.1.1.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     proc_macro_deps = [
@@ -48,6 +48,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=better_any"
     ],
     version = "0.1.1",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.better_typeid_derive-0.1.1.bazel
+++ b/library/crates/remote/BUILD.better_typeid_derive-0.1.1.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -30,13 +31,12 @@ licenses([
 
 # Generated Targets
 
-rust_library(
+rust_proc_macro(
     name = "better_typeid_derive",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "proc-macro",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=better_typeid_derive"
     ],
     version = "0.1.1",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.bit-set-0.5.2.bazel
+++ b/library/crates/remote/BUILD.bit-set-0.5.2.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -38,7 +39,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -47,6 +47,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=bit-set"
     ],
     version = "0.5.2",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.bit-vec-0.6.3.bazel
+++ b/library/crates/remote/BUILD.bit-vec-0.6.3.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -39,7 +40,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -48,6 +48,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=bit-vec"
     ],
     version = "0.6.3",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.bitflags-1.3.2.bazel
+++ b/library/crates/remote/BUILD.bitflags-1.3.2.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -37,7 +38,6 @@ rust_library(
         "default",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -46,6 +46,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=bitflags"
     ],
     version = "1.3.2",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.byteorder-1.4.3.bazel
+++ b/library/crates/remote/BUILD.byteorder-1.4.3.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -40,7 +41,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -49,6 +49,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=byteorder"
     ],
     version = "1.4.3",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/library/crates/remote/BUILD.cfg-if-1.0.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=cfg-if"
     ],
     version = "1.0.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.instant-0.1.12.bazel
+++ b/library/crates/remote/BUILD.instant-0.1.12.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=instant"
     ],
     version = "0.1.12",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/library/crates/remote/BUILD.lazy_static-1.4.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=lazy_static"
     ],
     version = "1.4.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.libc-0.2.106.bazel
+++ b/library/crates/remote/BUILD.libc-0.2.106.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -69,7 +70,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -78,6 +78,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=libc"
     ],
     version = "0.2.106",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.lock_api-0.4.5.bazel
+++ b/library/crates/remote/BUILD.lock_api-0.4.5.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -36,7 +37,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -45,6 +45,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=lock_api"
     ],
     version = "0.4.5",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.murmur3-0.4.1.bazel
+++ b/library/crates/remote/BUILD.murmur3-0.4.1.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -38,7 +39,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -47,6 +47,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=murmur3"
     ],
     version = "0.4.1",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.once_cell-1.8.0.bazel
+++ b/library/crates/remote/BUILD.once_cell-1.8.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -54,7 +55,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -63,6 +63,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=once_cell"
     ],
     version = "1.8.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.parking_lot-0.11.2.bazel
+++ b/library/crates/remote/BUILD.parking_lot-0.11.2.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -37,7 +38,6 @@ rust_library(
         "default",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -46,6 +46,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=parking_lot"
     ],
     version = "0.11.2",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.parking_lot_core-0.8.5.bazel
+++ b/library/crates/remote/BUILD.parking_lot_core-0.8.5.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -82,7 +83,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -91,6 +91,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=parking_lot_core"
     ],
     version = "0.8.5",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.proc-macro2-1.0.32.bazel
+++ b/library/crates/remote/BUILD.proc-macro2-1.0.32.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -69,7 +70,6 @@ rust_library(
         "proc-macro",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -78,6 +78,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=proc-macro2"
     ],
     version = "1.0.32",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.quote-1.0.10.bazel
+++ b/library/crates/remote/BUILD.quote-1.0.10.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -40,7 +41,6 @@ rust_library(
         "proc-macro",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -49,6 +49,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=quote"
     ],
     version = "1.0.10",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.redox_syscall-0.2.10.bazel
+++ b/library/crates/remote/BUILD.redox_syscall-0.2.10.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -45,7 +46,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -54,6 +54,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=syscall"
     ],
     version = "0.2.10",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/library/crates/remote/BUILD.scopeguard-1.1.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -38,7 +39,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -47,6 +47,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=scopeguard"
     ],
     version = "1.1.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.smallvec-1.7.0.bazel
+++ b/library/crates/remote/BUILD.smallvec-1.7.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -38,7 +39,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -47,6 +47,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=smallvec"
     ],
     version = "1.7.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.syn-1.0.81.bazel
+++ b/library/crates/remote/BUILD.syn-1.0.81.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -85,7 +86,6 @@ rust_library(
         "quote",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -94,6 +94,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=syn"
     ],
     version = "1.0.81",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.typed-arena-2.0.1.bazel
+++ b/library/crates/remote/BUILD.typed-arena-2.0.1.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -40,7 +41,6 @@ rust_library(
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -49,6 +49,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=typed_arena"
     ],
     version = "2.0.1",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.unicode-xid-0.2.2.bazel
+++ b/library/crates/remote/BUILD.unicode-xid-0.2.2.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -39,7 +40,6 @@ rust_library(
         "default",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -48,6 +48,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=unicode-xid"
     ],
     version = "0.2.2",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.uuid-0.8.2.bazel
+++ b/library/crates/remote/BUILD.uuid-0.8.2.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -43,14 +44,11 @@ licenses([
 rust_library(
     name = "uuid",
     srcs = glob(["**/*.rs"]),
-    aliases = {
-    },
     crate_features = [
         "default",
         "std",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2018",
     rustc_flags = [
@@ -59,16 +57,10 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=uuid"
     ],
     version = "0.8.2",
     # buildifier: leave-alone
     deps = [
-    ] + selects.with_or({
-        # cfg(windows)
-        (
-            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
-        ): [
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )

--- a/library/crates/remote/BUILD.winapi-0.3.9.bazel
+++ b/library/crates/remote/BUILD.winapi-0.3.9.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -79,7 +80,6 @@ rust_library(
         "winnt",
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -88,6 +88,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=winapi"
     ],
     version = "0.3.9",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/library/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -65,7 +66,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -74,6 +74,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=winapi-i686-pc-windows-gnu"
     ],
     version = "0.4.0",
     # buildifier: leave-alone

--- a/library/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/library/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -10,9 +10,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 # buildifier: disable=load
 load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     "rust_binary",
     "rust_library",
+    "rust_proc_macro",
     "rust_test",
 )
 
@@ -65,7 +66,6 @@ rust_library(
     crate_features = [
     ],
     crate_root = "src/lib.rs",
-    crate_type = "lib",
     data = [],
     edition = "2015",
     rustc_flags = [
@@ -74,6 +74,7 @@ rust_library(
     tags = [
         "cargo-raze",
         "manual",
+        "crate-name=winapi-x86_64-pc-windows-gnu"
     ],
     version = "0.4.0",
     # buildifier: leave-alone


### PR DESCRIPTION
## What is the goal of this PR?

Allow `assemble_crate` to retrieve the original crate name by looking at `tags` attribute

## What are the changes implemented in this PR?

* Regenerate `//library/crates` to include fixes from google/cargo-raze#455
* Bump `@vaticle_bazel_distribution`