### PR TITLE
Update create-notes to escape notes and use time-ordering

### DIFF
--- a/tool/release/createnotes/CreateNotes.kt
+++ b/tool/release/createnotes/CreateNotes.kt
@@ -24,6 +24,7 @@ package com.vaticle.dependencies.tool.release.createnotes
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.notExists
+import kotlin.text.Regex.Companion.escapeReplacement
 
 fun main(args: Array<String>) {
     val bazelWorkspaceDir = Paths.get(getEnv("BUILD_WORKSPACE_DIRECTORY"))
@@ -50,6 +51,6 @@ private fun writeNotesMd(notes: List<Note>, releaseTemplateFile: Path) {
     val template = releaseTemplateFile.toFile().readText()
     if (!template.matches(".*${Constant.releaseTemplateRegex.pattern}.*".toRegex(RegexOption.DOT_MATCHES_ALL)))
         throw RuntimeException("The release-template does not contain the '${Constant.releaseTemplateRegex}' placeholder")
-    val markdown = template.replace(Constant.releaseTemplateRegex, Note.toMarkdown(notes))
+    val markdown = template.replace(Constant.releaseTemplateRegex, escapeReplacement(Note.toMarkdown(notes)))
     releaseTemplateFile.toFile().writeText(markdown)
 }

--- a/tool/release/createnotes/Note.kt
+++ b/tool/release/createnotes/Note.kt
@@ -75,7 +75,7 @@ class Note {
                 if (line.startsWith("##")) {
                     header += 1
                 } else if (header == 1) {
-                    goal.append(line)
+                    goal.append(line).append("\n")
                 } else if (header > 1) {
                     break
                 }
@@ -120,7 +120,7 @@ ${others.map(Note::toMarkdown).joinToString("\n")}
 }
 
 fun collectNotes(org: String, repo: String, commits: List<String>, githubToken: String): List<Note> {
-    return commits.flatMap { commit ->
+     return commits.reversed().flatMap { commit ->
         val pullsRes = httpGet("$github/repos/$org/$repo/commits/$commit/pulls", githubToken)
         val pullsJSON = Json.parse(pullsRes.parseAsString())
         val prs = pullsJSON.asArray()


### PR DESCRIPTION
## What is the goal of this PR?

We fix release-note creation by escaping the notes inserted into the release template. The create-notes process used a regex to perform string replacement, which was not treating the replacement value as a literal string, but a regex as well, leading to errors. We also reverse the commits before generating the notes, so we get most-recent-first in the generated github release.

## What are the changes implemented in this PR?

* escape the regex replacement string (ie. the notes markdown)
* reverse the order of commits before generating the release notes, so we get most recent commits first rather than last