### PR TITLE
Fix expired cert error, temporarily

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,3 @@
 build --incompatible_strict_action_env
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env
-
-try-import /opt/credentials/bazel-remote-cache.rc
-


### PR DESCRIPTION
## What is the goal of this PR?

We disabled importing RBE credentials due to an expired cert, but should reintroduce them in the future.

## What are the changes implemented in this PR?

Don't import RBE credentials
