### PR TITLE
Make 'release version bump' tool push to the remote Git repo

### DIFF
--- a/tool/release/version/BUILD
+++ b/tool/release/version/BUILD
@@ -22,7 +22,9 @@ kt_jvm_binary(
     srcs = ["Bump.kt"],
     main_class = "com.vaticle.dependencies.tool.release.version.BumpKt",
     deps = [
-        "@maven//:com_eclipsesource_minimal_json_minimal_json",
-        "@maven//:com_google_http_client_google_http_client",
+        "@vaticle_bazel_distribution//common",
+        "@vaticle_bazel_distribution//common/shell",
+
+        "@maven//:org_zeroturnaround_zt_exec",
     ],
 )

--- a/tool/release/version/BUILD
+++ b/tool/release/version/BUILD
@@ -17,6 +17,8 @@
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
 
+package(default_visibility = ["//visibility:public"])
+
 kt_jvm_binary(
     name = "bump",
     srcs = ["Bump.kt"],

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -18,6 +18,7 @@ fun main() {
         ?: throw RuntimeException("GRABL_BRANCH environment variable is not set")
     val workspacePath = Paths.get(workspaceDirectory)
 
+    configureGitCredentials()
     shell.execute(listOf("git", "checkout", branchName), baseDir = workspacePath)
 
     val versionFile = workspacePath.resolve("VERSION")
@@ -29,6 +30,16 @@ fun main() {
     Files.write(versionFile, newVersion.toByteArray())
 
     gitCommitAndPush(workspacePath, newVersion)
+}
+
+fun configureGitCredentials() {
+    val gitUsername = System.getenv("GIT_USERNAME")
+        ?: throw RuntimeException("GIT_USERNAME environment variable is not set")
+    val gitEmail = System.getenv("GIT_EMAIL")
+        ?: throw RuntimeException("GIT_EMAIL environment variable is not set")
+
+    shell.execute(listOf("git", "config", "--global", "user.name", gitUsername))
+    shell.execute(listOf("git", "config", "--global", "user.email", gitEmail))
 }
 
 fun bumpVersion(version: String): String {
@@ -57,7 +68,7 @@ fun bumpVersion(version: String): String {
 
 fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
     shell.execute(listOf("git", "add", "VERSION"), baseDir = workspacePath)
-    shell.execute(listOf("git", "commit", "-m", "\"Bump version number to $newVersion\""), baseDir = workspacePath)
+    shell.execute(listOf("git", "commit", "-m", "Bump version number to $newVersion"), baseDir = workspacePath)
     val maxRetries = 3
     var retryCount = 0
     while (retryCount < maxRetries) {

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -76,7 +76,7 @@ fun bumpVersion(version: String): String {
 
 fun getRemoteURL(workspacePath: Path, gitToken: String): String {
     val gitRemoteOutput = shell.execute(listOf("git", "remote", "-v"), baseDir = workspacePath).outputString()
-    val regex = Regex("git@github\\.com:(\\w+)/(\\w+)\\.git")
+    val regex = Regex("git@github\\.com:([^/]+)/([^/]+)\\.git")
     val matchedGroups = regex.find(gitRemoteOutput)?.groupValues
     if (matchedGroups == null || matchedGroups.size < 3) {
         throw RuntimeException("Unable to parse 'git remote' output '$gitRemoteOutput'")

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -8,6 +8,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 val logger = Logger(DEBUG)
+val shell = Shell(logger)
 
 fun bumpVersion(version: String): String {
     val versionComponents = version.split(".").toTypedArray()
@@ -34,8 +35,6 @@ fun bumpVersion(version: String): String {
 }
 
 fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
-    val shell = Shell(logger)
-    shell.execute(listOf("git", "checkout", "master"), baseDir = workspacePath)
     shell.execute(listOf("git", "add", "VERSION"), baseDir = workspacePath)
     shell.execute(listOf("git", "commit", "-m", "\"Bump version number to $newVersion\""), baseDir = workspacePath)
     val maxRetries = 3
@@ -57,6 +56,9 @@ fun main() {
     val workspaceDirectory = System.getenv("BUILD_WORKSPACE_DIRECTORY")
             ?: throw RuntimeException("Not running from within Bazel workspace")
     val workspacePath = Paths.get(workspaceDirectory)
+
+    shell.execute(listOf("git", "checkout", "master"), baseDir = workspacePath)
+
     val versionFile = workspacePath.resolve("VERSION")
     val version = String(Files.readAllBytes(versionFile)).trim()
     val newVersion = bumpVersion(version)

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -35,7 +35,7 @@ fun bumpVersion(version: String): String {
 
 fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
     val shell = Shell(logger)
-    shell.execute(listOf("git", "remote", "-vv"), baseDir = workspacePath)
+    shell.execute(listOf("git", "checkout", "master"), baseDir = workspacePath)
     shell.execute(listOf("git", "add", "VERSION"), baseDir = workspacePath)
     shell.execute(listOf("git", "commit", "-m", "\"Bump version number to $newVersion\""), baseDir = workspacePath)
     val maxRetries = 3

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -1,19 +1,7 @@
 package com.vaticle.dependencies.tool.release.version
 
-import com.google.api.client.http.ByteArrayContent
-import com.google.api.client.http.GenericUrl
-import com.google.api.client.http.HttpHeaders
-import com.google.api.client.http.javanet.NetHttpTransport
 import java.nio.file.Files
 import java.nio.file.Paths
-
-fun postJson(url: String?, authorization: String, accept: String, content: String) {
-    NetHttpTransport()
-            .createRequestFactory()
-            .buildPostRequest(GenericUrl(url), ByteArrayContent.fromString("application/json", content))
-            .setHeaders(HttpHeaders().setAuthorization(authorization).setAccept(accept))
-            .execute()
-}
 
 fun bumpVersion(version: String): String {
     val versionComponents = version.split(".").toTypedArray()
@@ -45,24 +33,11 @@ fun bumpVersion(version: String): String {
 fun main() {
     val workspaceDirectory = System.getenv("BUILD_WORKSPACE_DIRECTORY")
             ?: throw RuntimeException("Not running from within Bazel workspace")
-    val githubToken = System.getenv("GITHUB_TOKEN")
-            ?: throw RuntimeException("GITHUB_TOKEN environment variable is not set")
-    val repoOwner = System.getenv("GRABL_OWNER")
-            ?: throw RuntimeException("GRABL_OWNER environment variable is not set")
-    val repoName = System.getenv("GRABL_REPO")
-            ?: throw RuntimeException("GRABL_REPO environment variable is not set")
 
     val versionFile = Paths.get(workspaceDirectory, "VERSION")
     val version = String(Files.readAllBytes(versionFile)).trim()
     val newVersion = bumpVersion(version)
 
-    println("Bumping the version to ${newVersion}")
+    println("Bumping the version to $newVersion")
     Files.write(versionFile, newVersion.toByteArray())
-
-    println("Creating new milestone ${newVersion} in ${repoOwner}/${repoName}")
-    postJson("https://api.github.com/repos/${repoOwner}/${repoName}/milestones",
-            "Token ${githubToken}",
-            "application/vnd.github.v3+json",
-            """{"title": "${newVersion}"}""")
-
 }

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -35,6 +35,7 @@ fun bumpVersion(version: String): String {
 
 fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
     val shell = Shell(logger)
+    shell.execute(listOf("git", "remote", "-vv"), baseDir = workspacePath)
     shell.execute(listOf("git", "add", "VERSION"), baseDir = workspacePath)
     shell.execute(listOf("git", "commit", "-m", "\"Bump version number to $newVersion\""), baseDir = workspacePath)
     val maxRetries = 3

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -1,14 +1,17 @@
 package com.vaticle.dependencies.tool.release.version
 
+import com.vaticle.bazel.distribution.common.Logging.LogLevel.DEBUG
+import com.vaticle.bazel.distribution.common.Logging.Logger
+import com.vaticle.bazel.distribution.common.shell.Shell
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+
+val logger = Logger(DEBUG)
 
 fun bumpVersion(version: String): String {
     val versionComponents = version.split(".").toTypedArray()
-
-    if (versionComponents.size != 3) {
-        throw RuntimeException("Version is supposed to have three components: x.y.z")
-    }
+    if (versionComponents.size != 3) throw RuntimeException("Version is supposed to have three components: x.y.z")
     var lastVersionComponent = versionComponents[versionComponents.lastIndex]
 
     try {
@@ -23,21 +26,41 @@ fun bumpVersion(version: String): String {
                     ).toString()
             lastVersionComponent = versionSubComponents.joinToString("-")
         } catch (b: NumberFormatException) {
-            throw RuntimeException("invalid version: ${version}")
+            throw RuntimeException("invalid version: $version")
         }
     }
     versionComponents[versionComponents.lastIndex] = lastVersionComponent
     return versionComponents.joinToString(".")
 }
 
+fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
+    val shell = Shell(logger)
+    shell.execute(listOf("git", "add", "VERSION"), baseDir = workspacePath)
+    shell.execute(listOf("git", "commit", "-m", "\"Bump version number to $newVersion\""), baseDir = workspacePath)
+    val maxRetries = 3
+    var retryCount = 0
+    while (retryCount < maxRetries) {
+        shell.execute(listOf("git", "pull"), baseDir = workspacePath)
+        try {
+            shell.execute(listOf("git", "push"), baseDir = workspacePath)
+            break
+        } catch (e: Exception) {
+            // cover the unlikely but possible edge case where someone else has already pushed
+            retryCount++
+        }
+    }
+}
+
 fun main() {
     val workspaceDirectory = System.getenv("BUILD_WORKSPACE_DIRECTORY")
             ?: throw RuntimeException("Not running from within Bazel workspace")
-
-    val versionFile = Paths.get(workspaceDirectory, "VERSION")
+    val workspacePath = Paths.get(workspaceDirectory)
+    val versionFile = workspacePath.resolve("VERSION")
     val version = String(Files.readAllBytes(versionFile)).trim()
     val newVersion = bumpVersion(version)
 
-    println("Bumping the version to $newVersion")
+    logger.debug { "Bumping the version to $newVersion" }
     Files.write(versionFile, newVersion.toByteArray())
+
+    gitCommitAndPush(workspacePath, newVersion)
 }

--- a/tool/release/version/Bump.kt
+++ b/tool/release/version/Bump.kt
@@ -47,6 +47,7 @@ fun gitCommitAndPush(workspacePath: Path, newVersion: String) {
         } catch (e: Exception) {
             // cover the unlikely but possible edge case where someone else has already pushed
             retryCount++
+            if (retryCount == maxRetries) throw e
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

`//release/version:bump` no longer creates a GitHub milestone, and now pushes to the remote Git repo.

## What are the changes implemented in this PR?

Previously, `//release/version:bump` behaved oddly, modifying the `VERSION` file but not committing the result to any repo. So we rebuilt it. The behaviour of the rule is:

1. Increment the number in the `VERSION` file
2. `git commit`
3. `git push`