### PR TITLE
Add Maven artifact: org.jetbrains.skiko:skiko-awt

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,6 +21,6 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "a4ff3778d65d6f4c563b70c096d150f7028800ce" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "e61daa787bc77d97e36df944e7223821cab309ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -250,9 +250,8 @@ artifacts = {
     "org.jetbrains.kotlin:kotlin-test": "1.6.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core": "1.6.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "1.6.0",
-    # Find out the Skiko version we need to use at:
-    # https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/ui/ui-graphics-desktop/
-    # https://mvnrepository.com/artifact/org.jetbrains.skiko/skiko-awt-runtime-macos-x64
+    # Find out the Skiko version we need by viewing dependencies of @maven//org_jetbrains_compose_ui_ui_graphics_desktop
+    "org.jetbrains.skiko:skiko-awt": "0.7.5",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-x64": "0.7.5",
     "org.jetbrains.skiko:skiko-awt-runtime-macos-x64": "0.7.5",
     "org.jetbrains.skiko:skiko-awt-runtime-windows-x64": "0.7.5",


### PR DESCRIPTION
## What is the goal of this PR?

We added the Maven artifact `org.jetbrains.skiko:skiko-awt`, which Studio uses. We also updated `bazel-distribution`, which means that duplicate Maven coordinates are now detected in `java_deps` and will fail the build.

## What are the changes implemented in this PR?

- Add Maven artifact: org.jetbrains.skiko:skiko-awt
- Update bazel-distribution