### PR TITLE
Add libraries necessary for testing compose-jb applications

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -242,6 +242,9 @@ artifacts = {
     "org.jetbrains.compose.ui:ui-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-geometry-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-graphics-desktop": "1.1.0-alpha04",
+    "org.jetbrains.compose.ui:ui-test-desktop": "1.1.0-alpha04",
+    "org.jetbrains.compose.ui:ui-test-junit4": "1.1.0-alpha04",
+    "org.jetbrains.compose.ui:ui-test-junit4-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-text-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-unit-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.runtime:runtime-desktop": "1.1.0-alpha04",
@@ -250,6 +253,7 @@ artifacts = {
     "org.jetbrains.kotlin:kotlin-test": "1.6.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core": "1.6.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "1.6.0",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-test": "1.6.0",
     # Find out the Skiko version we need by viewing dependencies of @maven//org_jetbrains_compose_ui_ui_graphics_desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.5",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-x64": "0.7.5",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -243,7 +243,6 @@ artifacts = {
     "org.jetbrains.compose.ui:ui-geometry-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-graphics-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-test-desktop": "1.1.0-alpha04",
-    "org.jetbrains.compose.ui:ui-test-junit4": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-test-junit4-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-text-desktop": "1.1.0-alpha04",
     "org.jetbrains.compose.ui:ui-unit-desktop": "1.1.0-alpha04",


### PR DESCRIPTION
## What is the goal of this PR?

Granting access to the testing libraries for compose-jb applications in preparation of adding testing to TypeDB Studio.

## What are the changes implemented in this PR?

We add three libraries from JetBrains: ui-test-desktop, ui-test-junit4-desktop and kotlinx-coroutines-test. The versions of these libraries are in line with their 'sister' libraries.