### PR TITLE
Update rules_nodejs to version 5.5.2

### DIFF
--- a/builder/nodejs/deps.bzl
+++ b/builder/nodejs/deps.bzl
@@ -3,8 +3,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps(patch = []):
     http_archive(
         name = "build_bazel_rules_nodejs",
-        sha256 = "f2194102720e662dbf193546585d705e645314319554c6ce7e47d8b59f459e9c",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz"],
+        sha256 = "c78216f5be5d451a42275b0b7dc809fb9347e2b04a68f68bad620a2b01f5c774",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.2/rules_nodejs-5.5.2.tar.gz"],
         patches = patch,
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Update the `bazelbuild/rules_nodejs` dependency to latest version which is 5.5.2. The update introduces some new features that make building npm projects easier.

## What are the changes implemented in this PR?

* Update `bazelbuild/rules_nodejs` dependency to version 5.5.2.
