### PR TITLE
Bump rules_docker and stop depending on Vaticle's fork

### DIFF
--- a/distribution/docker/deps.bzl
+++ b/distribution/docker/deps.bzl
@@ -3,7 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps():
     http_archive(
         name = "io_bazel_rules_docker",
-        sha256 = "e9d5e14a8021f1f29981b92d189c1b10715f6d77179ade89dc658f7363701cc6",
-        strip_prefix = "rules_docker-20c0025d44671df55c0b7bfc0ad649c740655185",
-        urls = ["https://github.com/vaticle/rules_docker/archive/20c0025d44671df55c0b7bfc0ad649c740655185.tar.gz"],
+        sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Bump the version of rules_docker and stop depending on Vaticle's fork. The issue that forced Vaticle to create the fork is already resolved in rules_docker. 

## What are the changes implemented in this PR?

* Bump the version of rules_docker
