### PR TITLE
Bump masmovil_bazel_rules

### DIFF
--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def deps():
     git_repository(
         name = "com_github_masmovil_bazel_rules",
-        commit = "7bd160b5fe0354052e98b1dfb0cc6c4300b58026",
         remote = "https://github.com/masmovil/bazel-rules.git",
+        commit = "7bd160b5fe0354052e98b1dfb0cc6c4300b58026",
     )

--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def deps():
     git_repository(

--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -1,9 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def deps():
-    http_archive(
+    git_repository(
         name = "com_github_masmovil_bazel_rules",
-        urls = ["https://github.com/vaticle/masmovil-bazel-rules/archive/846da589fee71012d5a8ba0102f692bf4b9a76b1.tar.gz"],
-        strip_prefix = "masmovil-bazel-rules-846da589fee71012d5a8ba0102f692bf4b9a76b1",
-        sha256 = "1207c2ad648ccf157951407c63cd60b8cb8d03d7ed6640123d6be5bb222bb620",
+        commit = "7bd160b5fe0354052e98b1dfb0cc6c4300b58026",
+        remote = "https://github.com/masmovil/bazel-rules.git",
     )


### PR DESCRIPTION
## What is the goal of this PR?

Bump masmovil_bazel_rules and stop depending on Vaticle's fork. The PRs submitted by Vaticle were merged into masmovil_bazel_rules, therefore we don't need to maintain the fork anymore.

## What are the changes implemented in this PR?

* Bump masmovil_bazel_rules and stop depending on Vaticle's fork
