### PR TITLE
Bump bazel-distribution

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -20,6 +20,6 @@
 build:
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //... --deleted_packages=library/rocksdbjni

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,6 +21,6 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/jamesreprise/vaticle-bazel-distribution",
-        commit = "d2040ed0b41347506097fa8d6d612a0e265b5742" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "5d61506c518795525e22448369e1a905fb0da23b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,6 +21,6 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/jamesreprise/vaticle-bazel-distribution",
-        commit = "c31d5e5796b98a68d83155b3d91bd1be28e61bd9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "adf3d6478d840f19f198acaf39535c95f310f2fc" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -20,7 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/jamesreprise/bazel-distribution",
+        remote = "https://github.com/jamesreprise/vaticle-bazel-distribution",
         commit = "d2040ed0b41347506097fa8d6d612a0e265b5742" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,6 +21,6 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/jamesreprise/vaticle-bazel-distribution",
-        commit = "5d61506c518795525e22448369e1a905fb0da23b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "c31d5e5796b98a68d83155b3d91bd1be28e61bd9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -20,7 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "d258c7fef80ecbd774e23604a94be32b060437b4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        remote = "https://github.com/jamesreprise/bazel-distribution",
+        commit = "d2040ed0b41347506097fa8d6d612a0e265b5742" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -20,7 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/jamesreprise/vaticle-bazel-distribution",
-        commit = "adf3d6478d840f19f198acaf39535c95f310f2fc" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        remote = "https://github.com/vaticle/bazel-distribution",
+        commit = "b17950a7e34b203a18a53217b61c7a7f45c30f25" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
     


### PR DESCRIPTION
## What is the goal of this PR?

We've updated bazel-distribution to propagate changes that update our use of Python. See the changes: 
- https://github.com/vaticle/bazel-distribution/pull/358

## What are the changes implemented in this PR?

We've updated bazel-distribution and changed the Ubuntu 21.04 image to 22.04.

## Additional information

We don't intend to commit the given change - this will pass as a CI run and once the PR for dependencies is merged, we will change our destination repository and hash.