### PR TITLE
Fix IDE sync tool generating binary names that are illegal in Cargo.toml

### DIFF
--- a/ide/rust/BUILD
+++ b/ide/rust/BUILD
@@ -23,6 +23,7 @@ java_binary(
         ":syncer",
     ],
     main_class = "com.vaticle.dependencies.ide.rust.SyncerKt",
+    visibility = ["//visibility:public"],
 )
 
 kt_jvm_library(

--- a/ide/rust/RepoCargoManifestGenerator.kt
+++ b/ide/rust/RepoCargoManifestGenerator.kt
@@ -148,8 +148,7 @@ class RepoCargoManifestGenerator(private val repository: File, shell: Shell) {
                 BIN -> {
                     createSubConfig().apply {
                         this@createEntryPointSubConfig.set<List<Config>>("bin", listOf(this))
-                        val binPathString = info.entryPointPath.toString()
-                        set<String>("name", binPathString.substring(0, binPathString.length - ".rs".length))
+                        set<String>("name", info.entryPointPath.toString().replace('/', '_').substringBeforeLast(".rs"))
                         set<String>("path", entryPointPath)
                     }
                 }


### PR DESCRIPTION
## What is the goal of this PR?

We fixed the IDE sync tool generating binary names that are illegal in `Cargo.toml`, and made the sync tool have `public` visibility so that other repos can verify it.

## What are the changes implemented in this PR?

Generated binary names are based on their project-relative path, ensuring uniqueness. But, they contained slashes, which are illegal in a `Cargo.toml` `[bin.name]`. So we now replace them with underscores.

Also, we've made the sync tool `public` so that other repos can declare it in their `:ci` `BUILD` targets.
