### PR TITLE
Exclude all rocksdbjni targets from build

### DIFF
--- a/library/rocksdbjni/BUILD
+++ b/library/rocksdbjni/BUILD
@@ -46,7 +46,7 @@ genrule(
     srcs = ["VERSION"],
     cmd = "$(execpath :builder-mac) && read -a outs <<< '$(OUTS)' && mv rocksdbjni-osx.jar $${outs[0]} && mv rocksdbjni-sources.jar $${outs[1]}",
     tools = ["@bazel_tools//tools/jdk:current_host_java_runtime", ":builder-mac"],
-    tags = ["manual"]
+    tags = ["manual", "no-ide"],
 )
 
 java_import(
@@ -65,6 +65,7 @@ assemble_maven(
     target = ":rocksdbjni-dev-mac",
     version_file = "VERSION",
     workspace_refs = "@vaticle_dependencies_workspace_refs//:refs.json",
+    tags = ["manual", "no-ide"],
 )
 
 deploy_maven(
@@ -72,7 +73,7 @@ deploy_maven(
     target = ":assemble-maven-mac",
     snapshot = deployment["maven.snapshot"],
     release = deployment["maven.release"],
-    tags = ["manual"]
+    tags = ["manual", "no-ide"],
 )
 
 kt_jvm_binary(
@@ -94,7 +95,7 @@ genrule(
     srcs = ["VERSION"],
     cmd = "$(execpath :builder-linux) && read -a outs <<< '$(OUTS)' && mv rocksdbjni-linux.jar $${outs[0]}",
     tools = ["@bazel_tools//tools/jdk:current_host_java_runtime", ":builder-linux"],
-    tags = ["manual"]
+    tags = ["manual", "no-ide"],
 )
 
 java_import(
@@ -110,7 +111,7 @@ assemble_maven(
     name = "assemble-maven-linux",
     target = ":rocksdbjni-dev-linux",
     version_file = "VERSION",
-    tags = ["manual"],
+    tags = ["manual", "no-ide"],
     project_description = "RocksDB JNI Mac Dev release by Vaticle",
     project_name = "RocksDB JNI Mac Dev",
     project_url = "https://github.com/vaticle/dependencies",
@@ -123,5 +124,5 @@ deploy_maven(
     target = ":assemble-maven-linux",
     snapshot = deployment["maven.snapshot"],
     release = deployment["maven.release"],
-    tags = ["manual"]
+    tags = ["manual", "no-ide"],
 )


### PR DESCRIPTION
## What is the goal of this PR?

We added the `manual` tag to `//library/rocksdbjni:assemble-maven-mac`. Previously, it didn't have this tag, so even though every other `rocksdbjni` target did, it was still getting compiled by `bazel build //...`. We also added "no-ide" to all rocksdbjni targets so that IDE tooling will ignore them.

## What are the changes implemented in this PR?

Because the "manual" tag wasn't set on `//library/rocksdbjni:assemble-maven-mac`, it was getting compiled by `bazel build //...` which dramatically increases the build time (it takes roughly 6 minutes to build this target alone). Now the build time of the repo is much, much faster.