### PR TITLE
Add transitive deps of `ortools` that aren't included by default on M1 Macs

### DIFF
--- a/library/crates/BUILD.bazel
+++ b/library/crates/BUILD.bazel
@@ -40,6 +40,15 @@ alias(
 )
 
 alias(
+    name = "core_foundation_sys",
+    actual = "@raze__core_foundation_sys__0_8_3//:core_foundation_sys",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "crossbeam",
     actual = "@raze__crossbeam__0_8_2//:crossbeam",
     tags = [
@@ -78,6 +87,15 @@ alias(
 alias(
     name = "futures",
     actual = "@raze__futures__0_3_21//:futures",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "libc",
+    actual = "@raze__libc__0_2_132//:libc",
     tags = [
         "cargo-raze",
         "manual",

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -10,10 +10,12 @@ antlr-rust = "=0.3.0-beta"
 axum = "=0.5.15"
 chrono = "=0.4.22"
 crossbeam = "=0.8.2"
+core-foundation-sys = "=0.8.3" # transitive dependency of 'iana_time_zone', included to patch cfg('unix') issue (#385)
 cxx = "=1.0.59"
 derivative = "=2.2.0"
 enum_dispatch = "=0.3.8"
 futures = { version = "=0.3.21", features = ["executor", "thread-pool"] }
+libc = "=0.2.132" # transitive dependency of 'cxx', included to patch cfg('unix') issue (#385)
 log = "=0.4.8"
 prost = "=0.11.0"
 rocksdb = "=0.17.0"

--- a/library/crates/crates.bzl
+++ b/library/crates/crates.bzl
@@ -329,11 +329,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__cxx_build__1_0_80",
-        url = "https://crates.io/api/v1/crates/cxx-build/1.0.80/download",
+        name = "raze__cxx_build__1_0_81",
+        url = "https://crates.io/api/v1/crates/cxx-build/1.0.81/download",
         type = "tar.gz",
-        strip_prefix = "cxx-build-1.0.80",
-        build_file = Label("//library/crates/remote:BUILD.cxx-build-1.0.80.bazel"),
+        strip_prefix = "cxx-build-1.0.81",
+        build_file = Label("//library/crates/remote:BUILD.cxx-build-1.0.81.bazel"),
     )
 
     maybe(

--- a/library/crates/remote/BUILD.cxx-build-1.0.81.bazel
+++ b/library/crates/remote/BUILD.cxx-build-1.0.81.bazel
@@ -47,7 +47,7 @@ rust_library(
         "crate-name=cxx-build",
         "manual",
     ],
-    version = "1.0.80",
+    version = "1.0.81",
     # buildifier: leave-alone
     deps = [
         "@raze__cc__1_0_73//:cc",

--- a/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
+++ b/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
@@ -57,7 +57,7 @@ cargo_build_script(
     version = "0.1.1",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__cxx_build__1_0_80//:cxx_build",
+        "@raze__cxx_build__1_0_81//:cxx_build",
     ],
 )
 

--- a/library/ortools/rust/BUILD
+++ b/library/ortools/rust/BUILD
@@ -26,6 +26,7 @@ rust_library(
     srcs = ["ortools.rs"],
     deps = [
         "@vaticle_dependencies//library/crates:cxx",
+        "@vaticle_dependencies//library/crates:libc",
         ":ortools_bridge",
     ]
 )


### PR DESCRIPTION
## What is the goal of this PR?

We added `core-foundation-sys` and `libc` explicitly as crate dependencies. They are conditional dependencies of `ortools`. Due to a bug, most likely in `cargo raze`, they are not included by default.

## What are the changes implemented in this PR?

`core-foundation-sys` and `libc` are conditional dependencies of the `ortools` crate. The condition is the Cargo condition `cfg('unix')`, which is supposed to represent any Unix system. Due to a bug, most likely in `cargo raze`, they are not correctly pulled in when the machine has `aarch64` architecture.

We'll raise an issue/PR in the relevant upstream repo (most likely `cargo-raze`), but for now, we need a workaround to get our projects building on an M1 Mac. This PR is that workaround. We'll declare the dependencies explicitly, and depend on them explicitly in the targets that require them - most notably `ortools` will explicitly depend on `libc`, and `typeql` will explicitly depend on `libc` and `core-foundation-sys`.