### PR TITLE
Support Apple Silicon in `cargo raze` crates

### DIFF
--- a/library/crates/BUILD.bazel
+++ b/library/crates/BUILD.bazel
@@ -40,15 +40,6 @@ alias(
 )
 
 alias(
-    name = "core_foundation_sys",
-    actual = "@raze__core_foundation_sys__0_8_3//:core_foundation_sys",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-)
-
-alias(
     name = "crossbeam",
     actual = "@raze__crossbeam__0_8_2//:crossbeam",
     tags = [
@@ -87,15 +78,6 @@ alias(
 alias(
     name = "futures",
     actual = "@raze__futures__0_3_21//:futures",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-)
-
-alias(
-    name = "libc",
-    actual = "@raze__libc__0_2_132//:libc",
     tags = [
         "cargo-raze",
         "manual",
@@ -167,8 +149,18 @@ alias(
 
 # Export file for Stardoc support
 exports_files(
-    [
-        "crates.bzl",
-    ],
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -10,12 +10,10 @@ antlr-rust = "=0.3.0-beta"
 axum = "=0.5.15"
 chrono = "=0.4.22"
 crossbeam = "=0.8.2"
-core-foundation-sys = "=0.8.3" # transitive dependency of 'iana_time_zone', included to patch cfg('unix') issue (#385)
 cxx = "=1.0.59"
 derivative = "=2.2.0"
 enum_dispatch = "=0.3.8"
 futures = { version = "=0.3.21", features = ["executor", "thread-pool"] }
-libc = "=0.2.132" # transitive dependency of 'cxx', included to patch cfg('unix') issue (#385)
 log = "=0.4.8"
 prost = "=0.11.0"
 rocksdb = "=0.17.0"
@@ -38,6 +36,7 @@ package_aliases_dir = "."
 
 # The set of targets to generate BUILD rules for.
 targets = [
+    "aarch64-apple-darwin",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",

--- a/library/crates/remote/BUILD.android_system_properties-0.1.5.bazel
+++ b/library/crates/remote/BUILD.android_system_properties-0.1.5.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "android_system_properties",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.antlr-rust-0.3.0-beta.bazel
+++ b/library/crates/remote/BUILD.antlr-rust-0.3.0-beta.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "antlr_rust",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.async-stream-0.3.3.bazel
+++ b/library/crates/remote/BUILD.async-stream-0.3.3.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "async_stream",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.async-stream-impl-0.3.3.bazel
+++ b/library/crates/remote/BUILD.async-stream-impl-0.3.3.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "async_stream_impl",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.async-trait-0.1.57.bazel
+++ b/library/crates/remote/BUILD.async-trait-0.1.57.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_proc_macro(
     name = "async_trait",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.autocfg-1.1.0.bazel
+++ b/library/crates/remote/BUILD.autocfg-1.1.0.bazel
@@ -42,8 +42,6 @@ licenses([
 rust_library(
     name = "autocfg",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.axum-core-0.2.7.bazel
+++ b/library/crates/remote/BUILD.axum-core-0.2.7.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "axum_core",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2021",

--- a/library/crates/remote/BUILD.bazel
+++ b/library/crates/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/library/crates/remote/BUILD.bumpalo-3.11.1.bazel
+++ b/library/crates/remote/BUILD.bumpalo-3.11.1.bazel
@@ -36,9 +36,6 @@ licenses([
 rust_library(
     name = "bumpalo",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2021",

--- a/library/crates/remote/BUILD.cexpr-0.6.0.bazel
+++ b/library/crates/remote/BUILD.cexpr-0.6.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "cexpr",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/library/crates/remote/BUILD.cfg-if-0.1.10.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "cfg_if",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/library/crates/remote/BUILD.cfg-if-1.0.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "cfg_if",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.chrono-0.4.22.bazel
+++ b/library/crates/remote/BUILD.chrono-0.4.22.bazel
@@ -71,7 +71,6 @@ rust_library(
         "@raze__num_traits__0_2_15//:num_traits",
         "@raze__time__0_1_44//:time",
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.codespan-reporting-0.11.1.bazel
+++ b/library/crates/remote/BUILD.codespan-reporting-0.11.1.bazel
@@ -44,8 +44,6 @@ licenses([
 rust_library(
     name = "codespan_reporting",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.core-foundation-sys-0.8.3.bazel
+++ b/library/crates/remote/BUILD.core-foundation-sys-0.8.3.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "core_foundation_sys",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.cxx-build-1.0.81.bazel
+++ b/library/crates/remote/BUILD.cxx-build-1.0.81.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "cxx_build",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.cxxbridge-macro-1.0.59.bazel
+++ b/library/crates/remote/BUILD.cxxbridge-macro-1.0.59.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "cxxbridge_macro",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.derivative-2.2.0.bazel
+++ b/library/crates/remote/BUILD.derivative-2.2.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "derivative",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.enum_dispatch-0.3.8.bazel
+++ b/library/crates/remote/BUILD.enum_dispatch-0.3.8.bazel
@@ -40,8 +40,6 @@ licenses([
 rust_proc_macro(
     name = "enum_dispatch",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.fastrand-1.8.0.bazel
+++ b/library/crates/remote/BUILD.fastrand-1.8.0.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "fastrand",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.fixedbitset-0.4.2.bazel
+++ b/library/crates/remote/BUILD.fixedbitset-0.4.2.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "fixedbitset",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.form_urlencoded-1.0.1.bazel
+++ b/library/crates/remote/BUILD.form_urlencoded-1.0.1.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "form_urlencoded",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.futures-macro-0.3.24.bazel
+++ b/library/crates/remote/BUILD.futures-macro-0.3.24.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "futures_macro",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.getrandom-0.2.7.bazel
+++ b/library/crates/remote/BUILD.getrandom-0.2.7.bazel
@@ -57,10 +57,10 @@ rust_library(
     deps = [
         "@raze__cfg_if__1_0_0//:cfg_if",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],

--- a/library/crates/remote/BUILD.glob-0.3.0.bazel
+++ b/library/crates/remote/BUILD.glob-0.3.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "glob",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.h2-0.3.14.bazel
+++ b/library/crates/remote/BUILD.h2-0.3.14.bazel
@@ -40,8 +40,6 @@ licenses([
 rust_library(
     name = "h2",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.hermit-abi-0.1.19.bazel
+++ b/library/crates/remote/BUILD.hermit-abi-0.1.19.bazel
@@ -34,9 +34,6 @@ licenses([
 rust_library(
     name = "hermit_abi",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.http-0.2.8.bazel
+++ b/library/crates/remote/BUILD.http-0.2.8.bazel
@@ -46,8 +46,6 @@ licenses([
 rust_library(
     name = "http",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.http-body-0.4.5.bazel
+++ b/library/crates/remote/BUILD.http-body-0.4.5.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "http_body",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.http-range-header-0.3.0.bazel
+++ b/library/crates/remote/BUILD.http-range-header-0.3.0.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "http_range_header",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.httpdate-1.0.2.bazel
+++ b/library/crates/remote/BUILD.httpdate-1.0.2.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "httpdate",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.hyper-timeout-0.4.1.bazel
+++ b/library/crates/remote/BUILD.hyper-timeout-0.4.1.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "hyper_timeout",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.iana-time-zone-0.1.53.bazel
+++ b/library/crates/remote/BUILD.iana-time-zone-0.1.53.bazel
@@ -58,15 +58,14 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(any(target_os = "macos", target_os = "ios"))
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__core_foundation_sys__0_8_3//:core_foundation_sys",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(target_os = "windows")
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
+++ b/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -64,8 +62,6 @@ cargo_build_script(
 rust_library(
     name = "iana_time_zone_haiku",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.instant-0.1.12.bazel
+++ b/library/crates/remote/BUILD.instant-0.1.12.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "instant",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.itoa-1.0.3.bazel
+++ b/library/crates/remote/BUILD.itoa-1.0.3.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "itoa",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.jobserver-0.1.24.bazel
+++ b/library/crates/remote/BUILD.jobserver-0.1.24.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -53,10 +51,10 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],

--- a/library/crates/remote/BUILD.js-sys-0.3.60.bazel
+++ b/library/crates/remote/BUILD.js-sys-0.3.60.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "js_sys",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/library/crates/remote/BUILD.lazy_static-1.4.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "lazy_static",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.lazycell-1.3.0.bazel
+++ b/library/crates/remote/BUILD.lazycell-1.3.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "lazycell",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.libloading-0.7.3.bazel
+++ b/library/crates/remote/BUILD.libloading-0.7.3.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",
@@ -53,16 +51,15 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__cfg_if__1_0_0//:cfg_if",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.lock_api-0.4.8.bazel
+++ b/library/crates/remote/BUILD.lock_api-0.4.8.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -64,8 +62,6 @@ cargo_build_script(
 rust_library(
     name = "lock_api",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.log-0.4.8.bazel
+++ b/library/crates/remote/BUILD.log-0.4.8.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "log",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.matches-0.1.9.bazel
+++ b/library/crates/remote/BUILD.matches-0.1.9.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "matches",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.mime-0.3.16.bazel
+++ b/library/crates/remote/BUILD.mime-0.3.16.bazel
@@ -40,8 +40,6 @@ licenses([
 rust_library(
     name = "mime",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.mio-0.8.4.bazel
+++ b/library/crates/remote/BUILD.mio-0.8.4.bazel
@@ -64,16 +64,15 @@ rust_library(
     deps = [
         "@raze__log__0_4_8//:log",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.multimap-0.8.3.bazel
+++ b/library/crates/remote/BUILD.multimap-0.8.3.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "multimap",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.murmur3-0.4.1.bazel
+++ b/library/crates/remote/BUILD.murmur3-0.4.1.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "murmur3",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.num-integer-0.1.45.bazel
+++ b/library/crates/remote/BUILD.num-integer-0.1.45.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -70,8 +68,6 @@ cargo_build_script(
 rust_library(
     name = "num_integer",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.num-traits-0.2.15.bazel
+++ b/library/crates/remote/BUILD.num-traits-0.2.15.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -64,8 +62,6 @@ cargo_build_script(
 rust_library(
     name = "num_traits",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.num_cpus-1.13.1.bazel
+++ b/library/crates/remote/BUILD.num_cpus-1.13.1.bazel
@@ -38,8 +38,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",
@@ -55,10 +53,10 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(not(windows))
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],

--- a/library/crates/remote/BUILD.parking_lot_core-0.8.5.bazel
+++ b/library/crates/remote/BUILD.parking_lot_core-0.8.5.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -58,15 +56,14 @@ cargo_build_script(
     visibility = ["//visibility:private"],
     deps = [
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
@@ -80,8 +77,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -101,16 +96,15 @@ rust_library(
         "@raze__instant__0_1_12//:instant",
         "@raze__smallvec__1_9_0//:smallvec",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.peeking_take_while-0.1.2.bazel
+++ b/library/crates/remote/BUILD.peeking_take_while-0.1.2.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "peeking_take_while",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.percent-encoding-2.1.0.bazel
+++ b/library/crates/remote/BUILD.percent-encoding-2.1.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "percent_encoding",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.petgraph-0.6.2.bazel
+++ b/library/crates/remote/BUILD.petgraph-0.6.2.bazel
@@ -58,8 +58,6 @@ licenses([
 rust_library(
     name = "petgraph",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.pin-project-1.0.12.bazel
+++ b/library/crates/remote/BUILD.pin-project-1.0.12.bazel
@@ -58,8 +58,6 @@ licenses([
 rust_library(
     name = "pin_project",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.pin-project-internal-1.0.12.bazel
+++ b/library/crates/remote/BUILD.pin-project-internal-1.0.12.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "pin_project_internal",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.pin-project-lite-0.2.9.bazel
+++ b/library/crates/remote/BUILD.pin-project-lite-0.2.9.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "pin_project_lite",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.pin-utils-0.1.0.bazel
+++ b/library/crates/remote/BUILD.pin-utils-0.1.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "pin_utils",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.prettyplease-0.1.18.bazel
+++ b/library/crates/remote/BUILD.prettyplease-0.1.18.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2021",
@@ -64,8 +62,6 @@ cargo_build_script(
 rust_library(
     name = "prettyplease",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2021",

--- a/library/crates/remote/BUILD.prost-derive-0.11.0.bazel
+++ b/library/crates/remote/BUILD.prost-derive-0.11.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "prost_derive",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2021",

--- a/library/crates/remote/BUILD.prost-types-0.11.1.bazel
+++ b/library/crates/remote/BUILD.prost-types-0.11.1.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "prost_types",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2021",

--- a/library/crates/remote/BUILD.rand-0.8.5.bazel
+++ b/library/crates/remote/BUILD.rand-0.8.5.bazel
@@ -63,10 +63,10 @@ rust_library(
         "@raze__rand_chacha__0_3_1//:rand_chacha",
         "@raze__rand_core__0_6_3//:rand_core",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],

--- a/library/crates/remote/BUILD.redox_syscall-0.2.16.bazel
+++ b/library/crates/remote/BUILD.redox_syscall-0.2.16.bazel
@@ -43,8 +43,6 @@ alias(
 rust_library(
     name = "syscall",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.remove_dir_all-0.5.3.bazel
+++ b/library/crates/remote/BUILD.remove_dir_all-0.5.3.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",
@@ -53,7 +51,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.ryu-1.0.11.bazel
+++ b/library/crates/remote/BUILD.ryu-1.0.11.bazel
@@ -38,8 +38,6 @@ licenses([
 rust_library(
     name = "ryu",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/library/crates/remote/BUILD.scopeguard-1.1.0.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "scopeguard",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.scratch-1.0.2.bazel
+++ b/library/crates/remote/BUILD.scratch-1.0.2.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "scratch",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.serde_urlencoded-0.7.1.bazel
+++ b/library/crates/remote/BUILD.serde_urlencoded-0.7.1.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "serde_urlencoded",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.smallvec-1.9.0.bazel
+++ b/library/crates/remote/BUILD.smallvec-1.9.0.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "smallvec",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.socket2-0.4.6.bazel
+++ b/library/crates/remote/BUILD.socket2-0.4.6.bazel
@@ -54,16 +54,15 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.sync_wrapper-0.1.1.bazel
+++ b/library/crates/remote/BUILD.sync_wrapper-0.1.1.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "sync_wrapper",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.tempfile-3.3.0.bazel
+++ b/library/crates/remote/BUILD.tempfile-3.3.0.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -56,16 +54,15 @@ rust_library(
         "@raze__fastrand__1_8_0//:fastrand",
         "@raze__remove_dir_all__0_5_3//:remove_dir_all",
     ] + selects.with_or({
-        # cfg(any(unix, target_os = "wasi"))
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.termcolor-1.1.3.bazel
+++ b/library/crates/remote/BUILD.termcolor-1.1.3.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -53,7 +51,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.time-0.1.44.bazel
+++ b/library/crates/remote/BUILD.time-0.1.44.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",
@@ -54,7 +52,6 @@ rust_library(
     deps = [
         "@raze__libc__0_2_132//:libc",
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.tokio-1.20.1.bazel
+++ b/library/crates/remote/BUILD.tokio-1.20.1.bazel
@@ -77,15 +77,14 @@ cargo_build_script(
     deps = [
         "@raze__autocfg__1_1_0//:autocfg",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
@@ -145,16 +144,15 @@ rust_library(
         "@raze__pin_project_lite__0_2_9//:pin_project_lite",
         "@raze__socket2__0_4_6//:socket2",
     ] + selects.with_or({
-        # cfg(unix)
         (
             "@rules_rust//rust/platform:x86_64-apple-darwin",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+            "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             "@raze__libc__0_2_132//:libc",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.tokio-io-timeout-1.2.0.bazel
+++ b/library/crates/remote/BUILD.tokio-io-timeout-1.2.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "tokio_io_timeout",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.tokio-macros-1.8.0.bazel
+++ b/library/crates/remote/BUILD.tokio-macros-1.8.0.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "tokio_macros",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.tower-layer-0.3.1.bazel
+++ b/library/crates/remote/BUILD.tower-layer-0.3.1.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "tower_layer",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.tower-service-0.3.2.bazel
+++ b/library/crates/remote/BUILD.tower-service-0.3.2.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "tower_service",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.tracing-attributes-0.1.22.bazel
+++ b/library/crates/remote/BUILD.tracing-attributes-0.1.22.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_proc_macro(
     name = "tracing_attributes",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.try-lock-0.2.3.bazel
+++ b/library/crates/remote/BUILD.try-lock-0.2.3.bazel
@@ -34,8 +34,6 @@ licenses([
 rust_library(
     name = "try_lock",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.unicode-ident-1.0.3.bazel
+++ b/library/crates/remote/BUILD.unicode-ident-1.0.3.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "unicode_ident",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.unicode-width-0.1.10.bazel
+++ b/library/crates/remote/BUILD.unicode-width-0.1.10.bazel
@@ -34,9 +34,6 @@ licenses([
 rust_library(
     name = "unicode_width",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.want-0.3.0.bazel
+++ b/library/crates/remote/BUILD.want-0.3.0.bazel
@@ -36,8 +36,6 @@ licenses([
 rust_library(
     name = "want",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
+++ b/library/crates/remote/BUILD.wasi-0.10.0+wasi-snapshot-preview1.bazel
@@ -34,10 +34,6 @@ licenses([
 rust_library(
     name = "wasi",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
+++ b/library/crates/remote/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
@@ -34,10 +34,6 @@ licenses([
 rust_library(
     name = "wasi",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasm-bindgen-0.2.83.bazel
+++ b/library/crates/remote/BUILD.wasm-bindgen-0.2.83.bazel
@@ -42,11 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-        "default",
-        "spans",
-        "std",
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -66,11 +61,6 @@ cargo_build_script(
 rust_library(
     name = "wasm_bindgen",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "default",
-        "spans",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
+++ b/library/crates/remote/BUILD.wasm-bindgen-backend-0.2.83.bazel
@@ -34,9 +34,6 @@ licenses([
 rust_library(
     name = "wasm_bindgen_backend",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "spans",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasm-bindgen-macro-0.2.83.bazel
+++ b/library/crates/remote/BUILD.wasm-bindgen-macro-0.2.83.bazel
@@ -34,9 +34,6 @@ licenses([
 rust_proc_macro(
     name = "wasm_bindgen_macro",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "spans",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
+++ b/library/crates/remote/BUILD.wasm-bindgen-macro-support-0.2.83.bazel
@@ -34,9 +34,6 @@ licenses([
 rust_library(
     name = "wasm_bindgen_macro_support",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-        "spans",
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.wasm-bindgen-shared-0.2.83.bazel
+++ b/library/crates/remote/BUILD.wasm-bindgen-shared-0.2.83.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -64,8 +62,6 @@ cargo_build_script(
 rust_library(
     name = "wasm_bindgen_shared",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.which-4.2.5.bazel
+++ b/library/crates/remote/BUILD.which-4.2.5.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -55,7 +53,6 @@ rust_library(
         "@raze__either__1_8_0//:either",
         "@raze__libc__0_2_132//:libc",
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/library/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "winapi_i686_pc_windows_gnu",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/library/crates/remote/BUILD.winapi-util-0.1.5.bazel
@@ -36,8 +36,6 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = {
     },
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",
@@ -53,7 +51,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # cfg(windows)
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/library/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2015",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "winapi_x86_64_pc_windows_gnu",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2015",

--- a/library/crates/remote/BUILD.windows-sys-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows-sys-0.36.1.bazel
@@ -65,7 +65,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
     ] + selects.with_or({
-        # x86_64-pc-windows-msvc
         (
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [

--- a/library/crates/remote/BUILD.windows_aarch64_msvc-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows_aarch64_msvc-0.36.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "windows_aarch64_msvc",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.windows_i686_gnu-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows_i686_gnu-0.36.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "windows_i686_gnu",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.windows_i686_msvc-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows_i686_msvc-0.36.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "windows_i686_msvc",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.windows_x86_64_gnu-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows_x86_64_gnu-0.36.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "windows_x86_64_gnu",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/crates/remote/BUILD.windows_x86_64_msvc-0.36.1.bazel
+++ b/library/crates/remote/BUILD.windows_x86_64_msvc-0.36.1.bazel
@@ -42,8 +42,6 @@ cargo_build_script(
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
-    crate_features = [
-    ],
     crate_root = "build.rs",
     data = glob(["**"]),
     edition = "2018",
@@ -63,8 +61,6 @@ cargo_build_script(
 rust_library(
     name = "windows_x86_64_msvc",
     srcs = glob(["**/*.rs"]),
-    crate_features = [
-    ],
     crate_root = "src/lib.rs",
     data = [],
     edition = "2018",

--- a/library/ortools/rust/BUILD
+++ b/library/ortools/rust/BUILD
@@ -26,7 +26,6 @@ rust_library(
     srcs = ["ortools.rs"],
     deps = [
         "@vaticle_dependencies//library/crates:cxx",
-        "@vaticle_dependencies//library/crates:libc", # transitive dependency of 'cxx', included to patch cfg('unix') issue (#385)
         ":ortools_bridge",
     ]
 )


### PR DESCRIPTION
## What is the goal of this PR?

We configured `cargo raze` to generate targets that support Apple Silicon systems.

## What are the changes implemented in this PR?

`cargo raze`'s config file, `Cargo.toml`, defines the list of crates to pull in, as well as the list of platforms to target:
```toml
# The set of targets to generate BUILD rules for.
targets = [
    "x86_64-apple-darwin",
    "x86_64-pc-windows-msvc",
    "x86_64-unknown-linux-gnu",
]
```
We need to add `aarch64-apple-darwin` to support Apple Silicon.