### PR TITLE
Exclude 'target' and '.DS_Store' from checkstyle coverage

### DIFF
--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -36,6 +36,7 @@ if __name__ == '__main__':
     workspace_files, _ = tc.shell_execute([
         'find', '.',
             '(', '-name', '.git',
+            '-o', '-name', '.DS_Store',
             '-o', '-name', '.idea',
             '-o', '-name', '.ijwb',
             '-o', '-name', '.github',
@@ -44,6 +45,7 @@ if __name__ == '__main__':
             '-o', '-name', 'VERSION',
             '-o', '-name', '*.md',
             '-o', '-name', 'node_modules',
+            '-o', '-name', 'target',
         ')', '-prune', '-o', '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     workspace_files = workspace_files.split()


### PR DESCRIPTION
## What is the goal of this PR?

We now exclude `target` and `.DS_Store` from checkstyle coverage tests.

## What are the changes implemented in this PR?

`target` is typically a generated folder (e.g. by `cargo`). `.DS_Store` is generated by Finder on a Mac. They should be excluded from checkstyle coverage.

NB: Fixing https://github.com/vaticle/dependencies/issues/253 would remove the need for this PR, but it's harder to do.