### PR TITLE
IDE sync: generate correct paths for transitive Vaticle deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ bazel-out
 bazel-dependencies
 bazel-testlogs
 tool/bazelcache/.terraform/*
+target
+
+builder/grpc/rust/Cargo.lock
+builder/grpc/rust/Cargo.toml
+
+library/ortools/rust/Cargo.lock
+library/ortools/rust/Cargo.toml

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ bazel-dependencies
 bazel-testlogs
 tool/bazelcache/.terraform/*
 target
-
-builder/grpc/rust/Cargo.lock
-builder/grpc/rust/Cargo.toml
-
-library/ortools/rust/Cargo.lock
-library/ortools/rust/Cargo.toml
+Cargo.lock
+Cargo.toml
+!library/crates/Cargo.toml

--- a/ide/rust/RepoCargoManifestGenerator.kt
+++ b/ide/rust/RepoCargoManifestGenerator.kt
@@ -23,7 +23,6 @@ package com.vaticle.dependencies.ide.rust
 
 import com.electronwill.nightconfig.core.Config
 import com.electronwill.nightconfig.toml.TomlWriter
-import com.vaticle.bazel.distribution.common.shell.Shell
 import com.vaticle.bazel.distribution.common.util.FileUtil.listFilesRecursively
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Type.BIN
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Type.BUILD
@@ -34,8 +33,6 @@ import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.Paths.CARGO_
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.Paths.EXTERNAL
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.Paths.EXTERNAL_PLACEHOLDER
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.Paths.IDE_SYNC_PROPERTIES
-import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.ShellArgs.BAZEL
-import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.ShellArgs.INFO
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.BUILD_DEPS
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.DEPS_PREFIX
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.EDITION
@@ -55,11 +52,8 @@ import java.nio.file.Path
 import java.util.Properties
 import kotlin.io.path.Path
 
-class RepoCargoManifestGenerator(private val repository: File, shell: Shell) {
+class RepoCargoManifestGenerator(private val repository: File, private val bazelOutputBase: File) {
 
-    private val bazelOutputBase = File(
-        shell.execute(listOf(BAZEL, INFO, "output_base"), repository.toPath()).outputString().trim()
-    )
     private val bazelBin = repository.resolve(BAZEL_BIN).toPath().toRealPath().toFile()
 
     fun generateManifests() {
@@ -306,11 +300,6 @@ class RepoCargoManifestGenerator(private val repository: File, shell: Shell) {
         const val EXTERNAL = "external"
         const val EXTERNAL_PLACEHOLDER = "{external}"
         const val IDE_SYNC_PROPERTIES = "ide-sync.properties"
-    }
-
-    private object ShellArgs {
-        const val BAZEL = "bazel"
-        const val INFO = "info"
     }
 
     companion object {

--- a/ide/rust/Syncer.kt
+++ b/ide/rust/Syncer.kt
@@ -96,7 +96,7 @@ class Syncer : Callable<Unit> {
             logger.debug { "Syncing $repository" }
             cleanupOldSyncInfo()
             runSyncInfoAspect()
-            RepoCargoManifestGenerator(repository.toFile(), shell).generateManifests()
+            RepoCargoManifestGenerator(repository.toFile(), bazelOutputBase.toFile()).generateManifests()
             logger.debug { "Sync completed in $repository" }
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

The Rust IDE sync tool now generates the correct paths for transitive `@vaticle` dependencies.

## What are the changes implemented in this PR?

Simple explanation:
- Bazel flattens our dependencies and transitive dependencies into a single directory;
- but the `Cargo.toml` we generated behaved as if they were not flattened, but were rather tree-structured. Now, we behave correctly.

More detailed explanation:
Previously, the paths of `@vaticle` dependencies were generated relative to `$(bazel info output_base)` as executed from whatever Bazel workspace the sync tool was currently building. This meant that, for example, if `cloud` depended on `typedb-client-rust` which depended on `typedb-protocol`, we'd generate `bazel-cloud/external/vaticle_typedb_protocol/grpc/rust/Cargo.toml`, but the `Cargo.toml` we generated in `typedb-client-rust` would be looking for the fictitious `bazel-cloud/external/vaticle_typedb_client_rust/bazel-vaticle_typedb_client_rust/external/vaticle_typedb_protocol/grpc/rust/Cargo.toml`.

Now, all paths of `@vaticle` dependencies are generated relative to `$(bazel info output_base)` as executed from the Bazel workspace the sync tool was _launched_ from - i.e. always from the same root.