### PR TITLE
IDE sync: generate correct paths for crates containing generated sources

### DIFF
--- a/ide/rust/RepoCargoManifestGenerator.kt
+++ b/ide/rust/RepoCargoManifestGenerator.kt
@@ -41,7 +41,7 @@ import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncIn
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.NAME
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.PATH
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.ROOT_PATH
-import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.SOURCES_ARE_GENERATED
+import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.CONTAINS_GENERATED_SOURCES
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.TYPE
 import com.vaticle.dependencies.ide.rust.RepoCargoManifestGenerator.TargetSyncInfo.Keys.VERSION
 import java.io.File
@@ -128,7 +128,7 @@ class RepoCargoManifestGenerator(private val repository: File, private val bazel
         }
 
         private fun Config.createEntryPointSubConfig() {
-            val entryPointPath = if (info.sourcesAreGenerated) {
+            val entryPointPath = if (info.containsGeneratedSources) {
                 bazelBin.resolve(info.entryPointPath.toString()).toString()
             } else info.rootPath!!.relativize(info.entryPointPath!!).toString()
 
@@ -183,7 +183,7 @@ class RepoCargoManifestGenerator(private val repository: File, private val bazel
         val buildDeps: Collection<String>,
         val rootPath: Path?,
         val entryPointPath: Path?,
-        val sourcesAreGenerated: Boolean,
+        val containsGeneratedSources: Boolean,
         val tests: MutableCollection<TargetSyncInfo>,
         val buildScripts: MutableCollection<TargetSyncInfo>,
     ) {
@@ -258,7 +258,7 @@ class RepoCargoManifestGenerator(private val repository: File, private val bazel
                         buildDeps = props.getProperty(BUILD_DEPS, "").split(",").filter { it.isNotBlank() },
                         rootPath = props.getProperty(ROOT_PATH)?.let { Path(it) },
                         entryPointPath = props.getProperty(ENTRY_POINT_PATH)?.let { Path(it) },
-                        sourcesAreGenerated = props.getProperty(SOURCES_ARE_GENERATED).toBoolean(),
+                        containsGeneratedSources = props.getProperty(CONTAINS_GENERATED_SOURCES).toBoolean(),
                         tests = mutableListOf(),
                         buildScripts = mutableListOf(),
                     )
@@ -289,7 +289,7 @@ class RepoCargoManifestGenerator(private val repository: File, private val bazel
             const val PATH = "path"
             const val ROOT_PATH = "root.path"
             const val TYPE = "type"
-            const val SOURCES_ARE_GENERATED = "sources.are.generated"
+            const val CONTAINS_GENERATED_SOURCES = "contains.generated.sources"
             const val VERSION = "version"
         }
     }

--- a/ide/rust/sync_info_aspect.bzl
+++ b/ide/rust/sync_info_aspect.bzl
@@ -132,6 +132,7 @@ def _sync_info(target, ctx, source_files, crate_info):
     props = {}
     target_type = "build" if _looks_like_cargo_build_script(target) else _TARGET_TYPES[ctx.rule.kind]
 
+
     props["name"] = crate_info.name
     props["type"] = target_type
     props["version"] = crate_info.version
@@ -140,7 +141,11 @@ def _sync_info(target, ctx, source_files, crate_info):
         props["root.path"] = _target_root_path(target)
         entry_point_file = _entry_point_file(target, ctx, source_files)
         props["entry.point.path"] = entry_point_file.short_path
-        props["sources.are.generated"] = not entry_point_file.is_source
+        contains_generated_sources = False
+        for source_file in source_files:
+            if not source_file.is_source:
+                contains_generated_sources = True
+        props["contains.generated.sources"] = contains_generated_sources
         props["build.deps"] = ",".join(crate_info.build_deps)
     for dep in crate_info.deps.items():
         props["deps." + dep[0]] = dep[1]


### PR DESCRIPTION
## What is the goal of this PR?

The Rust IDE sync tool now generates correct paths for crates that contain generated code.

## What are the changes implemented in this PR?

The IDE sync tool had a "sources are generated" flag which triggered when the entry point was generated, but not when other files (like TypeDB Protocol's `typedb.protocol.rs`) were generated. In this PR, we change "sources are generated" to "contains generated sources". When a crate contains generated sources, its generated `Cargo.toml` will now have its entry point set to a location inside `bazel-bin`.

### Why does this work?

The sync tool builds the project's Rust targets. When a target contains generated sources, Bazel not only places the generated sources in `bazel-bin`, but also creates a symlink in `bazel-bin` for every non-generated source file that links to the source file in the project's working directory. The above behaviour was added in:
- https://github.com/bazelbuild/rules_rust/pull/1340

So as long as the sync tool generates a `Cargo.toml` that points to `bazel-bin`, the resulting `Cargo.toml` can be successfully built using `cargo`.