### PR TITLE
Add itertools crate to cargo raze

### DIFF
--- a/library/crates/BUILD.bazel
+++ b/library/crates/BUILD.bazel
@@ -130,6 +130,15 @@ alias(
 )
 
 alias(
+    name = "itertools",
+    actual = "@raze__itertools__0_10_3//:itertools",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "log",
     actual = "@raze__log__0_4_8//:log",
     tags = [

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -19,6 +19,7 @@ cxx = "=1.0.59"
 derivative = "=2.2.0"
 enum_dispatch = "=0.3.8"
 futures = { version = "=0.3.21", features = ["executor", "thread-pool"] }
+itertools = "=0.10.3"
 log = "=0.4.8"
 pest = "=2.4.1"
 pest_derive = "=2.4.1"


### PR DESCRIPTION
## What is the goal of this PR?

We pin the version of the itertools crate and make it available through bazel.
