### PR TITLE
Rust IDE sync: compile generated sources

### DIFF
--- a/ide/rust/Syncer.kt
+++ b/ide/rust/Syncer.kt
@@ -96,7 +96,7 @@ class Syncer : Callable<Unit> {
             logger.debug { "Syncing $repository" }
             cleanupOldSyncInfo()
             runSyncInfoAspect()
-            RepoCargoManifestGenerator(repository.toFile(), bazelOutputBase.toFile()).generateManifests()
+            RepoCargoManifestGenerator(repository.toFile(), bazelOutputBase.toFile(), shell).generateManifests()
             logger.debug { "Sync completed in $repository" }
         }
 

--- a/ide/rust/sync_info_aspect.bzl
+++ b/ide/rust/sync_info_aspect.bzl
@@ -135,6 +135,7 @@ def _sync_info(target, ctx, source_files, crate_info):
 
     props["name"] = crate_info.name
     props["type"] = target_type
+    props["label"] = target.label
     props["version"] = crate_info.version
     if target_type in ["bin", "lib"]:
         props["edition"] = ctx.rule.attr.edition or "2021"


### PR DESCRIPTION
## What is the goal of this PR?

The Rust IDE sync tool now compiles generated sources in external repositories.

## What are the changes implemented in this PR?

Previously, `typedb-client-rust` would fail to build using `cargo`, because the sources of `typedb-protocol` - imported as an external Bazel repository - were not automatically compiled by the sync tool. So the generated `Cargo.toml` for that target pointed to a valid `lib.rs` file, but that `lib.rs` file depended on `typedb.protocol.rs`, which did not exist, because it had not been created.

Now, whenever the sync tool finds a Bazel Rust target that contains generated sources, it runs `bazel build` on that target to generate those sources.