### PR TITLE
Allow longer filenames in crate assembler

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "e18de018d1b1f58074cc180546a3d19039173d95" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "eea6d03f41d1b80ee72a6c3a9f72c9d3b5593c4b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?

We update to the newest version of bazel-distribution to benefit from https://github.com/vaticle/bazel-distribution/pull/364
