### PR TITLE
Only include versioned labels in Maven artifacts.snapshot

### DIFF
--- a/library/maven/update.kt
+++ b/library/maven/update.kt
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 
 fun main() {
     val baseDir = Paths.get(System.getenv("BUILD_WORKSPACE_DIRECTORY"))
-    val snapshotCommand = listOf("bazel", "query", "@maven//...")
+    val snapshotCommand = listOf("bazel", "query", "kind(alias, @maven//...)")
     val snapshotFile = baseDir.resolve("dependencies").resolve("maven").resolve("artifacts.snapshot")
 
     println("-------------------------")


### PR DESCRIPTION
## What is the goal of this PR?

We now only include versioned labels in a Maven `artifacts.snapshot` generated by `//library/maven:update`.

## What are the changes implemented in this PR?

Each non-versioned `@maven` target is a `jvm_import`. Each versioned `@maven` target is an `alias` that aliases the non-versioned target.

Therefore we can halve the size of `artifacts.snapshot` by changing the invocation
```
bazel query @maven//...
```
to
```
bazel query 'kind(alias, @maven//...)'
```

Closes #152 .