### PR TITLE
Update bazel-distribution

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "eea6d03f41d1b80ee72a6c3a9f72c9d3b5593c4b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "cdf8f3e3e009b3690d0f467b1ecc5b4f122a74fa" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
  "globset",
  "lazy_static",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3061,6 +3061,7 @@ name = "vaticle-dependencies"
 version = "0.0.0"
 dependencies = [
  "alcoholic_jwt",
+ "async-trait",
  "axum",
  "chrono",
  "clap",

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -21,10 +21,11 @@ name = "vaticle-dependencies"
 version = "0.0.0"
 
 [lib]
-path = "" # ignored by cargo raze
+path = "" # ignored by cargo generate-lockfile
 
 [dependencies]
 alcoholic_jwt = "=4091.0.0"
+async-trait = "=0.1.59"
 axum = { version = "=0.5.15", features = ["ws"] }
 chrono = "=0.4.23"
 clap = "=4.0.26"


### PR DESCRIPTION
## What is the goal of this PR?

We update the bazel-distribution dependency to gain access to the updated `assemble_crate` rule.

## What are the changes implemented in this PR?

Drive-by: restore the async-trait crate in Cargo.toml