### PR TITLE
Don't use Bazel in crate-universe lockfile update script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ bazel-bin
 bazel-out
 bazel-dependencies
 bazel-testlogs
-cargo
+library/crates/cargo
 tool/bazelcache/.terraform/*
 target
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bazel-bin
 bazel-out
 bazel-dependencies
 bazel-testlogs
+cargo
 tool/bazelcache/.terraform/*
 target
 Cargo.lock

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "nom_locate"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
 dependencies = [
  "bytecount",
  "memchr",

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
  "globset",
  "lazy_static",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecount"

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -22,15 +22,11 @@ set -ex
 
 [[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
 
-cargo_target=@rules_rust//rust/toolchain:current_cargo_files
-
-bazel build $cargo_target
-
-project_dir=$(bazel info workspace)
-cargo_relpath=$(bazel cquery $cargo_target --output starlark --starlark:expr="target.files.to_list()[0].path" 2>/dev/null)
-cargo=${project_dir}/${cargo_relpath}
-
 crates_home=$(cd "$(dirname "${path}")" && pwd -P)
 pushd "$crates_home" > /dev/null
-$cargo generate-lockfile
+if [ ! -x cargo ]; then
+    wget https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo -O cargo
+    chmod +x cargo
+fi
+./cargo generate-lockfile
 popd > /dev/null

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -25,7 +25,7 @@ set -ex
 crates_home=$(cd "$(dirname "${path}")" && pwd -P)
 pushd "$crates_home" > /dev/null
 if [ ! -x cargo ]; then
-    wget https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo -O cargo
+    curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
     chmod +x cargo
 fi
 ./cargo generate-lockfile

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -29,8 +29,8 @@ if [ ! -x cargo ]; then
     arch=${arch#(} && arch=${arch%)} # strip parentheses
     if [[ $arch == x86_64-apple-darwin* ]]; then
         curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
-    elif [[ $arch == arm64-apple-darwin* ]]; then  # relying on rosetta
-        curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
+    elif [[ $arch == arm64-apple-darwin* ]]; then
+        curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_arm64/cargo
     else
         echo "Unsupported architecture: $arch"
         exit 1

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -29,6 +29,8 @@ if [ ! -x cargo ]; then
     arch=${arch#(} && arch=${arch%)} # strip parentheses
     if [[ $arch == x86_64-apple-darwin* ]]; then
         curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
+    elif [[ $arch == arm64-apple-darwin* ]]; then  # relying on rosetta
+        curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
     else
         echo "Unsupported architecture: $arch"
         exit 1

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -25,7 +25,14 @@ set -ex
 crates_home=$(cd "$(dirname "${path}")" && pwd -P)
 pushd "$crates_home" > /dev/null
 if [ ! -x cargo ]; then
-    curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
+    arch=$(bash --version | head -n1 | grep -o '\S\+$')  # (arch-vendor-os)
+    arch=${arch#(} && arch=${arch%)} # strip parentheses
+    if [[ $arch == x86_64-apple-darwin* ]]; then
+        curl -o cargo https://repo.vaticle.com/repository/artifact/cargo-1.66.0_darwin_x86_64/cargo
+    else
+        echo "Unsupported architecture: $arch"
+        exit 1
+    fi
     chmod +x cargo
 fi
 ./cargo generate-lockfile


### PR DESCRIPTION
## What is the goal of this PR?

rules_rust's own way of repinning changed dependencies in `crates_repository`, i.e. by setting the `CARGO_BAZEL_REPIN` environment variable to `full` takes a prohibitively long time for minor changes to the cargo manifest. We instead opted for using `cargo generate-lockfile`, which takes an order of magnitude less time to complete (~10 s as opposed to 3-5 minutes).

Using the cargo executable provided by rules_rust seems to be the most correct approach to updating the lockfile. However, calling it directly requires Bazel to build the workspace. Since we have rust executables in dependencies (e.g. `//builder/grpc/rust:compile`), Bazel will attempt to fetch the crates. Fetching the crates will fail if the manifest and the lockfile don't match, which they won't, since we just changed the manifest and are attempting to regenerate the lockfile.

The options are:
1. use `CARGO_BAZEL_REPIN=full`, slow as it is;
2. use system `cargo`;
3. edit WORKSPACE temporarily from within `update.sh`;
4. download a `cargo` binary and use that to generate the lockfile.

We've chosen option 4 for this PR, as that is fast, doesn't rely on the user system as much as option 2, and isn't as hacky as option 3. It is, however, limited to darwin-x64 at present.

## What are the changes implemented in this PR?

In `library/crates/update.sh`, fetch the cargo executable from repo.vaticle.com and regenerate the lockfile using that.
