### PR TITLE
Improve crate name detection in Rust IDE sync

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "cdf8f3e3e009b3690d0f467b1ecc5b4f122a74fa" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "16f85fa14818c61bd0ed58553ab5d63f2039985d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?

`ide/rust:sync` is now more reliable at correctly detecting the crate names of all dependencies. In particular, crates with hyphens (such as `async-trait`) should no longer cause issues.

## What are the changes implemented in this PR?

Crate name detection has been reworked. Because `rules_rust` doesn't expose the original name of the crate downloaded from Cargo anywhere, we were unable to reliably get that crate name and put it into `Cargo.toml`. Now, we use string parsing against the target's label. This works because the label is (e.g):
```
@crates__async-trait-0.36.0//:async_trait
```
We take everything up to + excluding the first `.`, then take everything up to + excluding the last `-`, then strip `@crates__` from the front.

See also:
- https://github.com/vaticle/bazel-distribution/pull/367