### PR TITLE
Avoid depending on commit-based archives

### DIFF
--- a/builder/java/deps.bzl
+++ b/builder/java/deps.bzl
@@ -5,5 +5,5 @@ def deps():
         name = "rules_jvm_external",
         strip_prefix = "rules_jvm_external-3.2",
         sha256 = "82262ff4223c5fda6fb7ff8bd63db8131b51b413d26eb49e3131037e79e324af",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/3.2.zip",
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/3.2.zip",
     )

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "16f85fa14818c61bd0ed58553ab5d63f2039985d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "76429acc42dde1df866f05a25036f11c8440f2e2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )

--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def deps():
     http_archive(
         name = "com_github_masmovil_bazel_rules",
-        urls = ["https://github.com/vaticle/masmovil-bazel-rules/archive/846da589fee71012d5a8ba0102f692bf4b9a76b1.tar.gz"],
-        strip_prefix = "masmovil-bazel-rules-846da589fee71012d5a8ba0102f692bf4b9a76b1",
-        sha256 = "1207c2ad648ccf157951407c63cd60b8cb8d03d7ed6640123d6be5bb222bb620",
+        urls = ["https://github.com/vaticle/masmovil-bazel-rules/archive/refs/tags/2023-02-06-vaticle.tar.gz"],
+        strip_prefix = "masmovil-bazel-rules-2023-02-06-vaticle",
+        sha256 = "b8963e51cadf3418ac935b2dad85aeed98c7769d8a7364649cdfb9ecce92cd5a",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We refactored our dependency on `com_github_masmovil_bazel_rules` (where we get our Helm rules) to depend on a release instead of a commit SHA. 

## What are the changes implemented in this PR?

Recently GitHub was affected by a major incident where commit-based archives changed their SHAs, crippling our whole build infrastructure. `com_github_masmovil_bazel_rules` was one such affected package.

As a precaution, we've upgraded it to the latest version.

We also refactored our dependency on `rules_jvm_external`, which pointed to an outdated (but incidentally still working) GitHub URL format, and updated `bazel-distribution`, which previously depended on `bazel-skylib` by commit SHA.