### PR TITLE
Update checkstyle to use original authorship year

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/bazel/BUILD
+++ b/builder/bazel/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/bazel/deps.bzl
+++ b/builder/bazel/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/grpc/BUILD
+++ b/builder/grpc/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/grpc/deps.bzl
+++ b/builder/grpc/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/grpc/rust/BUILD
+++ b/builder/grpc/rust/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/grpc/rust/BUILD
+++ b/builder/grpc/rust/BUILD
@@ -29,5 +29,6 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     license_type = "agpl-header",
+    year = "2018",
     size = "small",
 )

--- a/builder/grpc/rust/compile.bzl
+++ b/builder/grpc/rust/compile.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/builder/grpc/rust/compile.rs
+++ b/builder/grpc/rust/compile.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 Vaticle
+// Copyright (C) 2018-present Vaticle
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/distribution/deployment.bzl
+++ b/distribution/deployment.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/distribution/rpm/BUILD
+++ b/distribution/rpm/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/ide/rust/BUILD
+++ b/ide/rust/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/ide/rust/RepoCargoManifestGenerator.kt
+++ b/ide/rust/RepoCargoManifestGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/ide/rust/Syncer.kt
+++ b/ide/rust/Syncer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/ide/rust/sync_info_aspect.bzl
+++ b/ide/rust/sync_info_aspect.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/BUILD
+++ b/images/docker/ubuntu/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/Dockerfile
+++ b/images/docker/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/assemble-docker.sh
+++ b/images/docker/ubuntu/assemble-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/deploy-docker.sh
+++ b/images/docker/ubuntu/deploy-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/deployment.bzl
+++ b/images/docker/ubuntu/deployment.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/images/docker/ubuntu/version-docker.sh
+++ b/images/docker/ubuntu/version-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/crates/BUILD
+++ b/library/crates/BUILD
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/crates/crates.bzl
+++ b/library/crates/crates.bzl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/crates/update.sh
+++ b/library/crates/update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/maven/BUILD
+++ b/library/maven/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/ortools/cc/BUILD
+++ b/library/ortools/cc/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/ortools/cc/deps.bzl
+++ b/library/ortools/cc/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/ortools/rust/BUILD
+++ b/library/ortools/rust/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/library/ortools/rust/OrToolsWrapper.h
+++ b/library/ortools/rust/OrToolsWrapper.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 Vaticle
+// Copyright (C) 2018-present Vaticle
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/library/ortools/rust/ortools.rs
+++ b/library/ortools/rust/ortools.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 Vaticle
+// Copyright (C) 2018-present Vaticle
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/library/rocksdbjni/BUILD
+++ b/library/rocksdbjni/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/BUILD
+++ b/tool/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/bazelrun/rbe.py
+++ b/tool/bazelrun/rbe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/checkstyle/BUILD
+++ b/tool/checkstyle/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/checkstyle/config/checkstyle-file-agpl-header.txt
+++ b/tool/checkstyle/config/checkstyle-file-agpl-header.txt
@@ -1,6 +1,6 @@
 ^#!.*
 ^.*
-^.*Copyright \(C\) 2022 Vaticle$
+^.*Copyright \(C\) YEAR-present Vaticle$
 ^.*$
 ^.*This program is free software: you can redistribute it and/or modify$
 ^.*it under the terms of the GNU Affero General Public License as$

--- a/tool/checkstyle/config/checkstyle-file-apache-header.txt
+++ b/tool/checkstyle/config/checkstyle-file-apache-header.txt
@@ -1,6 +1,6 @@
 ^#!.*
 ^.*
-^.*Copyright \(C\) 2022 Vaticle$
+^.*Copyright \(C\) YEAR-present Vaticle$
 ^.*
 ^.*Licensed to the Apache Software Foundation \(ASF\) under one$
 ^.*or more contributor license agreements.  See the NOTICE file$

--- a/tool/checkstyle/config/checkstyle-file-commercial-fulltext.txt
+++ b/tool/checkstyle/config/checkstyle-file-commercial-fulltext.txt
@@ -1,4 +1,4 @@
-^Copyright \(C\) 2022 Vaticle$
+^Copyright \(C\) YEAR-present Vaticle$
 ^$
 ^This unpublished material is proprietary to Vaticle\.$
 ^All rights reserved\. The methods and$

--- a/tool/checkstyle/config/checkstyle-file-commercial-header.txt
+++ b/tool/checkstyle/config/checkstyle-file-commercial-header.txt
@@ -1,6 +1,6 @@
 ^#!.*
 ^.*
-^.*Copyright \(C\) 2022 Vaticle$
+^.*Copyright \(C\) YEAR-present Vaticle$
 ^.*$
 ^.*This unpublished material is proprietary to Vaticle.$
 ^.*All rights reserved. The methods and$

--- a/tool/checkstyle/deps.bzl
+++ b/tool/checkstyle/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -20,8 +20,10 @@ def _checkstyle_test_impl(ctx):
     opts = ctx.attr.opts
     sopts = ctx.attr.string_opts
 
-    license_file = "external/vaticle_dependencies/tool/checkstyle/config/checkstyle-file-%s.txt" % ctx.attr.license_type
+    license_file = "tool/checkstyle/config/checkstyle-file-%s.txt" % ctx.attr.license_type
 
+    if ctx.workspace_name != "vaticle_dependencies":
+        license_file = "external/vaticle_dependencies/" + license_file
     expanded_license_file = ctx.actions.declare_file("checkstyle-file-expanded-%s.txt" % ctx.attr.license_type)
     ctx.actions.run_shell(
         outputs = [ expanded_license_file ],

--- a/tool/checkstyle/templates/checkstyle.xml
+++ b/tool/checkstyle/templates/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (C) 2022 Vaticle
+  ~ Copyright (C) 2018-present Vaticle
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU Affero General Public License as

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/common/BUILD
+++ b/tool/common/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/jmh/BUILD
+++ b/tool/jmh/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/jmh/rules.bzl
+++ b/tool/jmh/rules.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/release/BUILD
+++ b/tool/release/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/release/deps/BUILD
+++ b/tool/release/deps/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/release/deps/rules.bzl
+++ b/tool/release/deps/rules.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/release/notes/BUILD
+++ b/tool/release/notes/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tool/release/notes/Commit.kt
+++ b/tool/release/notes/Commit.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/tool/release/notes/Note.kt
+++ b/tool/release/notes/Note.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/tool/release/notes/NotesCreate.kt
+++ b/tool/release/notes/NotesCreate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/tool/release/notes/Version.kt
+++ b/tool/release/notes/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2018-present Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/tool/release/version/BUILD
+++ b/tool/release/version/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/sonarcloud/BUILD
+++ b/tool/sonarcloud/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/unuseddeps/deps.bzl
+++ b/tool/unuseddeps/deps.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tool/util/BUILD
+++ b/tool/util/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Vaticle
+# Copyright (C) 2018-present Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
## What is the goal of this PR?

We've updated the checkstyle rules to use the style `2015-present` rather explicitly specifying the year and having to bump the year in the rest of the code every year.

## What are the changes implemented in this PR?

We've made changes to `checkstyle_test`, adding a year parameter alongside the `license_type` parameter, specifying the year in which the code was authored. If no year is specified, it defaults to 2015.