### PR TITLE
Section off cargo dev dependenciess

### DIFF
--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2813,9 +2813,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -25,13 +25,11 @@ path = "" # ignored by cargo generate-lockfile
 
 [dependencies]
 alcoholic_jwt = "=4091.0.0"
-async-std = { version = "=1.12.0", features = ["attributes"] }
 async-trait = "=0.1.59"
 axum = { version = "=0.5.15", features = ["ws"] }
 chrono = "=0.4.23"
 clap = "=4.0.26"
 crossbeam = "=0.8.2"
-cucumber = "=0.15.2"
 cxx = "=1.0.59"
 fluvio-helm = "=0.4.3"
 futures = { version = "=0.3.21", features = ["executor", "thread-pool"] }
@@ -52,9 +50,7 @@ reqwest = { version = "=0.11.12", features = ["json"] }
 rocksdb = "=0.19.0"
 serde = "=1.0.152"
 serde_json = "=1.0"
-serial_test = "=0.9.0"
 sha2 = "=0.10.6"
-smol = "=1.3.0"
 tokio = { version = "=1.24.1", features = ["rt", "rt-multi-thread"] }
 tokio-stream = "=0.1.11"
 tonic = { version = "=0.8.0", features = ["tls"] }
@@ -62,3 +58,9 @@ tonic-build = "=0.8.0"
 tracing = "=0.1.37"
 tracing-subscriber = "=0.3.16"
 uuid = { version = "=1.1.2", features = ["fast-rng", "v4"] }
+
+[dev-dependencies]
+async-std = { version = "=1.12.0", features = ["attributes"] }
+cucumber = "=0.15.2"
+serial_test = "=0.9.0"
+smol = "=1.3.0"


### PR DESCRIPTION
## What is the goal of this PR?

Mixing direct dependencies and those only used for testing purposes can cause confusion about which crates can be safely used as project dependencies. E.g., we wouldn't want a new project to use `async-std` runtime by mistake when everything else uses `tokio`. To alleviate that, we move all dependencies that should only be used in tests into the `[dev-dependencies]` section of Cargo.toml.