### PR TITLE
Allow PR body to be null in release notes generation tool

### DIFF
--- a/tool/release/notes/Note.kt
+++ b/tool/release/notes/Note.kt
@@ -51,9 +51,10 @@ class Note {
 
     companion object {
         fun fromGithubPR(pr: JsonObject): Note {
+            val bodyJsonValue = pr.get("body");
             return Note(
                     title = pr.get("title").asString(),
-                    goal = getPRGoal(pr.get("body").asString()),
+                    goal = getPRGoal(if (bodyJsonValue.isNull) null else bodyJsonValue.asString()),
                     type = getPRType(pr.get("labels").asArray())
             )
         }

--- a/tool/release/notes/Note.kt
+++ b/tool/release/notes/Note.kt
@@ -70,7 +70,8 @@ class Note {
             }
         }
 
-        private fun getPRGoal(description: String): String {
+        private fun getPRGoal(description: String?): String? {
+            if (description == null) return null
             val goal = StringBuilder()
             var header = 0
             for (line in description.lines()) {


### PR DESCRIPTION
## What is the goal of this PR?

We've updated some supporting functions in `Note.kt` to account for the fact that PR goals (i.e. the body of a PR) can be null.

## What are the changes implemented in this PR?

Update function signature and logic of `getPRGoal` to take a nullable String and return a nullable string.
