### PR TITLE
Remove dependency on forked rules_antlr

### DIFF
--- a/builder/antlr/deps.bzl
+++ b/builder/antlr/deps.bzl
@@ -3,8 +3,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def deps():
     git_repository(
         name = "rules_antlr",
-        remote = "https://github.com/vaticle/rules_antlr",
-        commit = "d64bb89db42e669b096c310b6b5f62e1565e1375"
+        remote = "https://github.com/marcohu/rules_antlr",
+        commit = "89a29cca479363a5aee53e203719510bdc6be6ff"
     )
 
-antlr_version = "4.8.2-rust"
+antlr_version = "4.8"

--- a/builder/antlr/rules.bzl
+++ b/builder/antlr/rules.bzl
@@ -9,15 +9,3 @@ def python_grammar_adapter(
         cmd_bash = "$(location @vaticle_dependencies//builder/antlr:grammar-adapter) --in $< --out $@ --adapt-keyword type --adapt-keyword filter",
         tools = ["@vaticle_dependencies//builder/antlr:grammar-adapter"],
     )
-
-def rust_grammar_adapter(
-        name,
-        input,
-        output):
-    native.genrule(
-        name = name,
-        srcs = [input],
-        outs = [output],
-        cmd_bash = "$(location @vaticle_dependencies//builder/antlr:grammar-adapter) --in $< --out $@ --adapt-keyword type",
-        tools = ["@vaticle_dependencies//builder/antlr:grammar-adapter"],
-    )


### PR DESCRIPTION
## What is the goal of this PR?

We revert our dependency on a fork of rules_antlr to depend instead on the original repository for the ANTLR code generation rules.

## What are the changes implemented in this PR?

Since we no longer use ANTLR for TypeQL Rust, depending on our own fork of rules_antlr which introduces Rust support is now obsolete.
