### PR TITLE
Update protobuf & gRPC dependencies

### DIFF
--- a/builder/grpc/deps.bzl
+++ b/builder/grpc/deps.bzl
@@ -16,20 +16,21 @@
 #
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def deps():
     git_repository(
         name = "com_github_grpc_grpc",
-        remote = "https://github.com/vaticle/grpc",
-        commit = "4a1528f6f20a8aa68bdbdc9a66286ec2394fc170"
+        remote = "https://github.com/grpc/grpc",
+        tag = "v1.52.0",
     )
     git_repository(
         name = "io_grpc_grpc_java",
         remote = "https://github.com/grpc/grpc-java",
-        commit = "62e8655f1bc4dfb474afbf332ca7571c1454e6ef"
+        tag = "v1.52.0",
     )
     git_repository(
         name = "stackb_rules_proto",
-        remote = "https://github.com/vaticle/rules_proto",
-        commit = "fd3aa227fdaa178c077ef9d72156b772d3b8c05d",
+        remote = "https://github.com/stackb/rules_proto",
+        tag = "1.0.0"
     )

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -38,7 +38,7 @@ artifacts = {
     "com.google.ortools:ortools-linux-x86-64-java": "8.0.8283",
     "com.google.ortools:ortools-win32-x86-64": "8.0.8283",
     "com.google.ortools:ortools-win32-x86-64-java": "8.0.8283",
-    "com.google.protobuf:protobuf-java": "3.14.0",
+    "com.google.protobuf:protobuf-java": "3.20.1",
     "com.jcraft:jsch": "0.1.55",
     "com.microsoft.azure:azure": "1.33.1",
     "com.microsoft.azure:azure-client-authentication": "1.7.4",


### PR DESCRIPTION
## What is the goal of this PR?

We update protobuf from 3.14 to 3.20, along with gRPC definition generation rules, removing reliance on some of our forked dependencies.
