### PR TITLE
Increase version of async-stripe crate to 0.22.2

### DIFF
--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -234,9 +234,8 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a328ed3276701b3f33127bf785ad4c4cd118e8d80b046ae397507c87730bbdb"
+version = "0.22.0"
+source = "git+https://github.com/sam-butcher/async-stripe.git?branch=usage_record_summary_id#c7dc8a15d0c70e9a438990b7eeaa1f617267e7a7"
 dependencies = [
  "chrono",
  "futures-util",

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -234,8 +234,8 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "0.22.0"
-source = "git+https://github.com/sam-butcher/async-stripe.git?branch=usage_record_summary_id#c7dc8a15d0c70e9a438990b7eeaa1f617267e7a7"
+version = "0.22.1"
+source = "git+https://github.com/sam-butcher/async-stripe.git?branch=usage_record_summary_id#10424938736b0ce87d3be99fccb053855f3ddd3c"
 dependencies = [
  "chrono",
  "futures-util",
@@ -252,6 +252,7 @@ dependencies = [
  "smart-default",
  "smol_str",
  "thiserror",
+ "time-core",
  "tokio",
  "uuid 0.8.2",
 ]
@@ -3138,6 +3139,12 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tinyvec"

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -234,8 +234,9 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "0.22.1"
-source = "git+https://github.com/sam-butcher/async-stripe.git?branch=usage_record_summary_id#10424938736b0ce87d3be99fccb053855f3ddd3c"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b313de0d654c4c4c46faa737b2257ce9ed79e69926aa4c734b9816be20102b2c"
 dependencies = [
  "chrono",
  "futures-util",

--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -585,15 +585,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "d0525278dce688103060006713371cedbad27186c7d913f33d866b498da0f595"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2299,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2688,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3735,9 +3735,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3745,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
@@ -3760,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.35"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3772,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3782,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3795,15 +3795,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -26,7 +26,7 @@ path = "" # ignored by cargo generate-lockfile
 [dependencies]
 hmac = "=0.12.1"
 alcoholic_jwt = "=4091.0.0"
-async-stripe = { version = "=0.18.4", features = ["runtime-tokio-hyper"] }
+async-stripe = { git = "https://github.com/sam-butcher/async-stripe.git", branch = "usage_record_summary_id", features = ["runtime-tokio-hyper"] }
 async-trait = "=0.1.59"
 axum = { version = "=0.5.15", features = ["ws"] }
 chrono = "=0.4.23"

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -26,7 +26,7 @@ path = "" # ignored by cargo generate-lockfile
 [dependencies]
 hmac = "=0.12.1"
 alcoholic_jwt = "=4091.0.0"
-async-stripe = { git = "https://github.com/sam-butcher/async-stripe.git", branch = "usage_record_summary_id", features = ["runtime-tokio-hyper"] }
+async-stripe = { version = "=0.22.2", features = ["runtime-tokio-hyper"] }
 async-trait = "=0.1.59"
 axum = { version = "=0.5.15", features = ["ws"] }
 chrono = "=0.4.23"


### PR DESCRIPTION
## What is the goal of this PR?

We increase the version of the `async-stripe` crate to `0.22.2` in order to make use of a new bugfix.

## What are the changes implemented in this PR?

We increase the version of `async-stripe` specified in `Cargo.toml` to `0.22.2` and re-generate the `Cargo.lock` accordingly.
