### PR TITLE
Allow extra SWIG includes and extra args

### DIFF
--- a/builder/swig/java.bzl
+++ b/builder/swig/java.bzl
@@ -52,7 +52,7 @@ def _swig_java_wrapper_impl(ctx):
         ]),
         outputs = [wrap_src, wrap_java_dir] + swig_headers,
         executable = ctx.file._swig,
-        arguments = ctx.attr.extra_args + args,
+        arguments = args,
     )
 
     wrap_zip = ctx.actions.declare_file(module_name + ".zip")


### PR DESCRIPTION
## What is the goal of this PR?

We add attributes to the SWIG Java rule that allow specifying extra files that may be included in the interface, and providing extra arguments to the SWIG executable. 

`enable_cxx` is provided as a separate attribute since in addition to providing the `-c++` flag it also affects the files generated by SWIG.