### PR TITLE
Add explicit jNaCl dependency for ZeroMQ key verification

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -74,6 +74,7 @@ artifacts = {
     "commons-io:commons-io": "2.3",
     "commons-lang:commons-lang": "2.6",
     "commons-logging:commons-logging": "1.2",
+    "eu.neilalexander:jnacl" : "1.0.0",
     "info.picocli:picocli": "4.6.1",
     "io.cucumber:cucumber-java": "5.1.3",
     "io.cucumber:cucumber-junit": "5.1.3",


### PR DESCRIPTION
## What is the goal of this PR?
Add explicit dependency on jNaCl (a java libsodium port), used for key pair validation in ZeroMQ. 

## What are the changes implemented in this PR?
* Adds jNaCl to `artifacts.bzl`.

(jNaCl is used internally by zeromq, so it has always been a runtime dependency)