### PR TITLE
Fix target label check in the cargo project generation

### DIFF
--- a/builder/rust/cargo/project_aspect.bzl
+++ b/builder/rust/cargo/project_aspect.bzl
@@ -179,7 +179,8 @@ def _copy_to_bin(ctx, src, dst):
     )
 
 def _should_generate_cargo_project(ctx, target):
-    return (str(target.label).startswith("@vaticle") or str(target.label).startswith("//")) and \
+    return (str(target.label).startswith("@vaticle") or str(target.label).startswith("//")
+        or str(target.label).startswith("@//")) and \
         ctx.rule.kind in _TARGET_TYPES and _TARGET_TYPES[ctx.rule.kind] in ["bin", "lib", "test"]
 
 def _is_universe_crate(target):


### PR DESCRIPTION
## What is the goal of this PR?

In Bazel 6.2.0 targets can start with `"@//"`. In `project_aspect.bzl` we have a target name check that is now updated according to this change in bazel.