### PR TITLE
Upgrade speedb to 2.6.0

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -89,7 +89,7 @@ artifacts = {
     "io.cucumber:cucumber-java": "5.1.3",
     "io.cucumber:cucumber-junit": "5.1.3",
     "io.github.microutils:kotlin-logging-jvm": "2.0.10",
-    "io.github.speedb-io:speedbjni": "2.4.1.5",
+    "io.github.speedb-io:speedbjni": "2.6.0",
     "io.grpc:grpc-api": "1.43.0",
     "io.grpc:grpc-context": "1.43.0",
     "io.grpc:grpc-core": "1.43.0",


### PR DESCRIPTION
## What is the goal of this PR?

We upgrade SpeeDB to 2.6.0, which is marginally faster even without any configuration changes.