### PR TITLE
Upgrade helm bazel rules

### DIFF
--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -1,9 +1,8 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def deps():
-    http_archive(
+    git_repository(
         name = "com_github_masmovil_bazel_rules",
-        urls = ["https://github.com/vaticle/masmovil-bazel-rules/archive/refs/tags/2023-02-06-vaticle.tar.gz"],
-        strip_prefix = "masmovil-bazel-rules-2023-02-06-vaticle",
-        sha256 = "b8963e51cadf3418ac935b2dad85aeed98c7769d8a7364649cdfb9ecce92cd5a",
+        tag = "v0.5.0",
+        remote = "https://github.com/masmovil/bazel-rules.git",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We upgrade masmovil bazel rules to v0.5.0
