### PR TITLE
Update bazel-distribution with artifact extractor fix

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "9467afb72bd33c5a304b67ebcc6af3cf7c2c2bde" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "5a56cd8a8cf296332dd187e383f7f39d88db12fc" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?

The updated `rules_pkg` (updated in https://github.com/vaticle/bazel-distribution/pull/382) packages `tar.gz` files without a leading `./` path. The artifact extractor therefore only needs to strip one layer from `tar.gz` files built by the `assemble_targz`, instead of two.
