### PR TITLE
Add arm64 skiko dependencies for TypeDB-Studio

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -290,7 +290,9 @@ artifacts = {
     "org.jetbrains.kotlinx:kotlinx-coroutines-test": "1.6.0",
     # Find out the Skiko version we need by viewing dependencies of @maven//org_jetbrains_compose_ui_ui_graphics_desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.34",
+    "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.34",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-x64": "0.7.34",
+    "org.jetbrains.skiko:skiko-awt-runtime-macos-arm64": "0.7.34",
     "org.jetbrains.skiko:skiko-awt-runtime-macos-x64": "0.7.34",
     "org.jetbrains.skiko:skiko-awt-runtime-windows-x64": "0.7.34",
     "org.kohsuke:github-api": "1.101",

--- a/util/platform/BUILD
+++ b/util/platform/BUILD
@@ -15,9 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load(":constraints.bzl", "constraint_aarch64", "constraint_x86_64", "constraint_linux", "constraint_mac", "constraint_windows",
-     "constraint_linux_aarch64", "constraint_linux_x86_64", "constraint_mac_aarch64", "constraint_mac_x86_64",
-      "constraint_win_x86_64")
+load(":constraints.bzl", "constraint_arm64", "constraint_x86_64", "constraint_linux", "constraint_mac", "constraint_windows",
+     "constraint_linux_arm64", "constraint_linux_x86_64", "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_arm64")
 
 config_setting(
     name = "is_linux",
@@ -35,8 +34,8 @@ config_setting(
 )
 
 config_setting(
-    name = "is_aarch64",
-    constraint_values = constraint_aarch64,
+    name = "is_arm64",
+    constraint_values = constraint_arm64,
 )
 
 config_setting(
@@ -45,8 +44,8 @@ config_setting(
 )
 
 config_setting(
-    name = "is_linux_aarch64",
-    constraint_values = constraint_linux_aarch64,
+    name = "is_linux_arm64",
+    constraint_values = constraint_linux_arm64,
 )
 
 config_setting(
@@ -55,8 +54,8 @@ config_setting(
 )
 
 config_setting(
-    name = "is_mac_aarch64",
-    constraint_values = constraint_mac_aarch64,
+    name = "is_mac_arm64",
+    constraint_values = constraint_mac_arm64,
 )
 
 config_setting(
@@ -70,8 +69,8 @@ config_setting(
 )
 
 platform(
-    name = "linux_aarch64",
-    constraint_values = constraint_linux_aarch64,
+    name = "linux_arm64",
+    constraint_values = constraint_linux_arm64,
 )
 
 platform(
@@ -80,8 +79,8 @@ platform(
 )
 
 platform(
-    name = "mac_aarch64",
-    constraint_values = constraint_mac_aarch64,
+    name = "mac_arm64",
+    constraint_values = constraint_mac_arm64,
 )
 
 platform(

--- a/util/platform/constraints.bzl
+++ b/util/platform/constraints.bzl
@@ -27,8 +27,8 @@ constraint_windows = [
     "@platforms//os:windows",
 ]
 
-constraint_aarch64 = [
-    "@platforms//cpu:aarch64",
+constraint_arm64 = [
+    "@platforms//cpu:arm64",
 ]
 
 constraint_x86_64 = [
@@ -36,7 +36,7 @@ constraint_x86_64 = [
 ]
 
 constraint_linux_x86_64 = constraint_linux + constraint_x86_64
-constraint_linux_aarch64 = constraint_linux + constraint_aarch64
+constraint_linux_arm64 = constraint_linux + constraint_arm64
 constraint_mac_x86_64 = constraint_mac + constraint_x86_64
-constraint_mac_aarch64 = constraint_mac + constraint_aarch64
+constraint_mac_arm64 = constraint_mac + constraint_arm64
 constraint_win_x86_64 = constraint_windows + constraint_x86_64


### PR DESCRIPTION
## What is the goal of this PR?

We add skiko linux- and macos-arm64 dependencies.

## What are the changes implemented in this PR?

Drive-by: rename aarch64 platform constraint to arm64.
