### PR TITLE
Remove stray win_arm64 reference

### DIFF
--- a/util/platform/BUILD
+++ b/util/platform/BUILD
@@ -16,7 +16,7 @@
 #
 
 load(":constraints.bzl", "constraint_arm64", "constraint_x86_64", "constraint_linux", "constraint_mac", "constraint_windows",
-     "constraint_linux_arm64", "constraint_linux_x86_64", "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_arm64")
+     "constraint_linux_arm64", "constraint_linux_x86_64", "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
 
 config_setting(
     name = "is_linux",


### PR DESCRIPTION
## What is the goal of this PR?

We remove the stray reference to the non-existence `constraint_win_arm64` rather than the present `constraint_win_x86_64`