### PR TITLE
Fix checkstyle coverage check for filenames with whitespaces

### DIFF
--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
             '-o', '-name', 'target',
         ')', '-prune', '-o', '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-    workspace_files = workspace_files.split()
+    workspace_files = workspace_files.split("\n")
 
     checkstyle_targets_xml, _ = tc.shell_execute([
         'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'


### PR DESCRIPTION
## What is the goal of this PR?

The checkstyle coverage check failed if there were files in the workspace with whitespaces in filenames. We fix it.

## What are the changes implemented in this PR?

The list of files was generated by splitting the `find` command result by all whitespace characters. But each file is listed in a separate line, that allows us to split by `"\n"` only.