### PR TITLE
Introduce dependencies and rules for C and C++

### DIFF
--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def deps():
     http_archive(
         name = "gtest",
-        sha256 = "1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4",
-        strip_prefix = "googletest-1.14.0",
-        urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"],
+        sha256 = "24564e3b712d3eb30ac9a85d92f7d720f60cc0173730ac166f27dda7fed76cb2",
+        strip_prefix = "googletest-release-1.12.1",
+        urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"],
     )

--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -1,0 +1,9 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def deps():
+    http_archive(
+        name = "gtest",
+        sha256 = "1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4",
+        strip_prefix = "googletest-1.14.0",
+        urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"],
+    )


### PR DESCRIPTION
## What is the goal of this PR?
Add google's GTEST as dependency for use in our C and C++ code in typedb-driver.

## What are the changes implemented in this PR?
* Introduces google's gtest library as a dependency.
