### PR TITLE
Enable native TLS roots feature on tonic

### DIFF
--- a/library/crates/Cargo.lock
+++ b/library/crates/Cargo.lock
@@ -2177,9 +2177,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.58"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2209,9 +2209,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.94"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -2798,6 +2798,18 @@ dependencies = [
  "ring 0.16.20",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3572,6 +3584,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
@@ -4325,18 +4338,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.23"
+version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50cbb27c30666a6108abd6bc7577556265b44f243e2be89a8bc4e07a528c107"
+checksum = "092cd76b01a033a9965b9097da258689d9e17c69ded5dcf41bca001dd20ebc6d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.23"
+version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25f293fe55f0a48e7010d65552bb63704f6ceb55a1a385da10d41d8f78e4a3d"
+checksum = "a13a20a7c6a90e2034bcc65495799da92efcec6a8dd4f3fcb6f7a48988637ead"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -24,20 +24,20 @@ version = "0.0.0"
 path = "" # ignored by cargo generate-lockfile
 
 [dependencies]
-hmac = "=0.12.1"
 alcoholic_jwt = "=4091.0.0"
 async-stripe = { version = "=0.22.2", features = ["runtime-tokio-hyper"] }
 async-trait = "=0.1.59"
 axum = { version = "=0.5.15", features = ["ws"] }
 chrono = "=0.4.23"
 clap = "=4.0.26"
-crossbeam = "=0.8.2"
 coerce = "0.8.3"
+crossbeam = "=0.8.2"
 cxx = "=1.0.59"
 enum_dispatch = "=0.3.11"
 env_logger = "=0.10.0"
 fluvio-helm = "=0.4.3"
 futures = { version = "=0.3.21", features = ["executor", "thread-pool"] }
+hmac = "=0.12.1"
 http = "=0.2.8"
 itertools = "=0.10.3"
 jsonwebtoken = "=8.3.0"
@@ -61,7 +61,7 @@ sha2 = "=0.10.6"
 tokio = { version = "=1.24.1", features = ["rt", "rt-multi-thread"] }
 tokio-retry = "=0.3.0"
 tokio-stream = "=0.1.11"
-tonic = { version = "=0.8.0", features = ["tls"] }
+tonic = { version = "=0.8.0", features = ["tls", "tls-roots"] }
 tonic-build = "=0.8.0"
 tower = "=0.4.13"
 tracing = "=0.1.37"


### PR DESCRIPTION
## What is the goal of this PR?

We've enabled the 'tls-roots' on our tonic crate. This means tonic will now trust all of the root certificates in the user's root certificate store when making connections.

## What are the changes implemented in this PR?

Enabled the 'tls-roots' feature flag on the tonic crate.

Drive-by: sort the crates alphabetically.