### PR TITLE
Pin JDK 17 versions and URLs

### DIFF
--- a/builder/compose/deps.bzl
+++ b/builder/compose/deps.bzl
@@ -3,31 +3,31 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def deps():
     http_file(
         name = "jdk17_linux_arm64",
-        urls = ["https://download.oracle.com/java/17/latest/jdk-17_linux-aarch64_bin.tar.gz"],
+        urls = ["https://download.oracle.com/java/17/archive/jdk-17.0.8_linux-aarch64_bin.tar.gz"],
         sha256 = "cd24d7b21ec0791c5a77dfe0d9d7836c5b1a8b4b75db7d33d253d07caa243117",
     )
 
     http_file(
         name = "jdk17_linux_x86_64",
-        urls = ["https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"],
+        urls = ["https://download.oracle.com/java/17/archive/jdk-17.0.8_linux-x64_bin.tar.gz"],
         sha256 = "74b528a33bb2dfa02b4d74a0d66c9aff52e4f52924ce23a62d7f9eb1a6744657",
     )
 
     http_file(
         name = "jdk17_mac_arm64",
-        urls = ["https://download.oracle.com/java/17/latest/jdk-17_macos-aarch64_bin.tar.gz"],
+        urls = ["https://download.oracle.com/java/17/archive/jdk-17.0.8_macos-aarch64_bin.tar.gz"],
         sha256 = "89f26bda33262d70455e774b55678fc259ae4f29c0a99eb0377d570507be3d04",
     )
 
     http_file(
         name = "jdk17_mac_x86_64",
-        urls = ["https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"],
+        urls = ["https://download.oracle.com/java/17/archive/jdk-17.0.8_macos-x64_bin.tar.gz"],
         sha256 = "ddc4928be11642f35b3cb1e6a56463032705fccb74e10ed5a67a73a5fc7b639f",
     )
 
     http_file(
         name = "jdk17_windows_x86_64",
-        urls = ["https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.zip"],
+        urls = ["https://download.oracle.com/java/17/archive/jdk-17.0.8_windows-x64_bin.zip"],
         sha256 = "98385c1fd4db7ad3fd7ca2f33a1fadae0b15486cfde699138d47002d7068084a",
     )
 


### PR DESCRIPTION
## What is the goal of this PR?

We replace the "latest" JDK 17 download links with the specific versions from the archive.