### PR TITLE
Switch to our patched version of rules_rust (based off v0.30.0)

### DIFF
--- a/builder/rust/deps.bzl
+++ b/builder/rust/deps.bzl
@@ -15,13 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def deps():
-    http_archive(
+    git_repository(
         name = "rules_rust",
-        sha256 = "b4e622a36904b5dd2d2211e40008fc473421c8b51c9efca746ab2ecf11dca08e",
-        urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.19.1/rules_rust-v0.19.1.tar.gz"],
+        remote = "https://github.com/vaticle/rules_rust",
+        commit = "2641f3aaf94a278ac2ef110a14c6c2d6c7eeb04a",
     )
     http_file(
         name = "cxxbridge_linux",

--- a/library/crates/crates.bzl
+++ b/library/crates/crates.bzl
@@ -16,9 +16,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@rules_rust//crate_universe:deps_bootstrap.bzl", "cargo_bazel_bootstrap")
 load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository", "render_config")
 
 def fetch_crates():
+    cargo_bazel_bootstrap() # Necessary to build cargo-bazel from sources
     crates_repository(
         name = "crates",
         cargo_lockfile = "@vaticle_dependencies//library/crates:Cargo.lock",
@@ -33,4 +35,5 @@ def fetch_crates():
             "x86_64-pc-windows-msvc",
             "x86_64-unknown-linux-gnu",
         ],
+        generator = "@cargo_bazel_bootstrap//:cargo-bazel"
     )


### PR DESCRIPTION
## What is the goal of this PR?

The patch resolves a long-standing issue with incorrect build dependency resolution when a dependency is also a disabled optional normal dependency. See https://github.com/bazelbuild/rules_rust/issues/2059.