### PR TITLE
Disable non-camel-case warnings in tonic compile

### DIFF
--- a/builder/grpc/rust/compile.rs
+++ b/builder/grpc/rust/compile.rs
@@ -22,6 +22,8 @@ fn main() -> std::io::Result<()> {
     let protos: Vec<&str> = protos_raw.split(";").filter(|&str| !str.is_empty()).collect();
 
     tonic_build::configure()
+        .server_mod_attribute(".", "#[allow(non_camel_case_types)]")
+        .client_mod_attribute(".", "#[allow(non_camel_case_types)]")
         .compile(&protos, &[
             env::var("PROTOS_ROOT").expect("PROTOS_ROOT environment variable is not set")
         ])


### PR DESCRIPTION
## What is the goal of this PR?

tonic-build gives gRPC methods that return a stream (e.g. `transaction()`) a dedicated type alias for the return type. The name of the type is `{method name}Stream`, which violates Rust naming conventions. We don't have control over those type names though, so the next best thing is disabling the diagnostic altogether.