### PR TITLE
Add rules and dependencies for C++ targets

### DIFF
--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -7,3 +7,59 @@ def deps():
         strip_prefix = "googletest-release-1.12.1",
         urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"],
     )
+
+    http_archive(
+        name = "gherkin_cpp",
+        urls = ["https://github.com/krishnangovindraj/gherkin/archive/refs/heads/main.zip"],
+        strip_prefix = "gherkin-main/cpp",
+        sha256 = "29e098c87c97cdd43b1449af2d9cb05e9b76359e4d8028647671fff7fffb85e2",
+        build_file_content = """
+cc_library(
+  name = "gherkin-lib",
+  deps = ["@nlohmann_json//:json", "@cucumber_messages//:cucumber-messages-lib"],
+  hdrs = glob(["include/**/*.hpp"]),
+  strip_include_prefix = "include",
+  srcs = glob(["src/lib/gherkin/**/*.cpp"]),
+  copts = ["--std=c++17"],
+  visibility= ["//visibility:public"],
+)
+        """
+    )
+
+    http_archive(
+        name = "cucumber_messages",
+        urls = ["https://github.com/krishnangovindraj/cucumber-messages/archive/refs/heads/main.zip"],
+        strip_prefix = "cucumber-messages-main/cpp",
+        sha256 = "369de231fdb01ee7a06cb75779dd4b2aa15f95bbf58c11286e2ea596a840f4b3",
+        build_file_content = """
+cc_library(
+  name = "cucumber-messages-lib",
+  deps = ["@nlohmann_json//:json"],
+  hdrs = glob(["include/**/*.hpp"]),
+  strip_include_prefix = "include",
+  srcs = glob(["src/lib/cucumber-messages/**/*.cpp", "src/lib/cucumber-messages/**/*.hpp"]),
+  copts = [
+    "--std=c++17",
+     "-isystem external/cucumber_messages/src/lib/cucumber-messages",
+  ],
+  visibility= ["@gherkin_cpp//:__pkg__", "//cpp/test:__subpackages__"],
+)
+    """
+    )
+
+    http_archive(
+        name = "nlohmann_json",
+        urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip"],
+        strip_prefix = "json-3.11.2",
+        sha256 = "95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9",
+        build_file_content = """
+cc_library(
+  name = "json",
+  hdrs = ["single_include/nlohmann/json.hpp"],
+  srcs = [],
+  includes = ["single_include"],
+  copts = ["--std=c++17"],
+  visibility= ["//visibility:public"],
+)
+    """
+    )

--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -10,9 +10,9 @@ def deps():
 
     http_archive(
         name = "gherkin_cpp",
-        urls = ["https://github.com/krishnangovindraj/gherkin/archive/refs/heads/main.zip"],
+        urls = ["https://github.com/vaticle/gherkin/archive/19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8.zip"],
         strip_prefix = "gherkin-main/cpp",
-        sha256 = "29e098c87c97cdd43b1449af2d9cb05e9b76359e4d8028647671fff7fffb85e2",
+        sha256 = "f8fd8d46b384a3c27a3bfed0e5eb1ad4ae2dbac862b18153a76178ec35a2c459",
         build_file_content = """
 cc_library(
   name = "gherkin-lib",
@@ -28,9 +28,9 @@ cc_library(
 
     http_archive(
         name = "cucumber_messages",
-        urls = ["https://github.com/krishnangovindraj/cucumber-messages/archive/refs/heads/main.zip"],
+        urls = ["https://github.com/vaticle/cucumber-messages/archive/fc5c391add237b0d5fa090072757a500863c24b7.zip"],
         strip_prefix = "cucumber-messages-main/cpp",
-        sha256 = "369de231fdb01ee7a06cb75779dd4b2aa15f95bbf58c11286e2ea596a840f4b3",
+        sha256 = "048a04c8b1163f601dc8992d41f3254a5ce58ac487514ee4ddd06090aa666d25",
         build_file_content = """
 cc_library(
   name = "cucumber-messages-lib",

--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -11,7 +11,7 @@ def deps():
     http_archive(
         name = "gherkin_cpp",
         urls = ["https://github.com/vaticle/gherkin/archive/19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8.zip"],
-        strip_prefix = "gherkin-main/cpp",
+        strip_prefix = "gherkin-19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8/cpp",
         sha256 = "f8fd8d46b384a3c27a3bfed0e5eb1ad4ae2dbac862b18153a76178ec35a2c459",
         build_file_content = """
 cc_library(
@@ -29,7 +29,7 @@ cc_library(
     http_archive(
         name = "cucumber_messages",
         urls = ["https://github.com/vaticle/cucumber-messages/archive/fc5c391add237b0d5fa090072757a500863c24b7.zip"],
-        strip_prefix = "cucumber-messages-main/cpp",
+        strip_prefix = "cucumber-messages-fc5c391add237b0d5fa090072757a500863c24b7/cpp",
         sha256 = "048a04c8b1163f601dc8992d41f3254a5ce58ac487514ee4ddd06090aa666d25",
         build_file_content = """
 cc_library(

--- a/builder/cpp/rules.bzl
+++ b/builder/cpp/rules.bzl
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+def _clang_format_test_impl(ctx):
+    files = []
+    for target in ctx.attr.include:
+        path = target.files.to_list()[0].path;
+        if target not in ctx.attr.exclude:
+            files.extend(target.files.to_list())
+
+    cmd = " ".join(
+        [ctx.file._clang_format_sh.path, ctx.file._clang_format_style.path] +
+        [file.path for file in files]
+    )
+
+    wrapper_script = ctx.actions.declare_file("clang_format_wrapper__%s.sh" % ctx.attr.name)
+    ctx.actions.write(
+        output = wrapper_script,
+        content = cmd,
+        is_executable = True,
+    )
+
+    files = [wrapper_script]  + [ctx.file._clang_format_sh, ctx.file._clang_format_style] + files
+    runfiles = ctx.runfiles(
+        files = files,
+        collect_data = True,
+    )
+    return DefaultInfo(
+        executable = wrapper_script,
+        files = depset(files),
+        runfiles = runfiles,
+    )
+
+clang_format_test = rule(
+    implementation = _clang_format_test_impl,
+    test = True,
+    attrs = {
+        "include": attr.label_list(
+            doc = "A list of files that should be checked",
+            allow_files = True,
+        ),
+        "exclude": attr.label_list(
+            doc = "A list of files that should be excluded from checking",
+            allow_files = True,
+            default = [],
+        ),
+        "_clang_format_sh": attr.label(
+             allow_single_file=True,
+             default = "//library/cpp:clang_format.sh"
+        ),
+        "_clang_format_style": attr.label(
+             allow_single_file=True,
+             default = "//library/cpp:.clang-format"
+        ),
+    },
+)

--- a/library/cpp/.clang-format
+++ b/library/cpp/.clang-format
@@ -3,7 +3,6 @@ BasedOnStyle: Chromium
 IndentWidth: 4
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 ColumnLimit: 0
-InsertNewlineAtEOF: true
 MaxEmptyLinesToKeep: 2
 AccessModifierOffset: -4
 ---

--- a/library/cpp/.clang-format
+++ b/library/cpp/.clang-format
@@ -1,0 +1,8 @@
+---
+BasedOnStyle: Chromium
+IndentWidth: 4
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+ColumnLimit: 0
+InsertNewlineAtEOF: true
+MaxEmptyLinesToKeep: 2
+---

--- a/library/cpp/.clang-format
+++ b/library/cpp/.clang-format
@@ -5,4 +5,5 @@ AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 ColumnLimit: 0
 InsertNewlineAtEOF: true
 MaxEmptyLinesToKeep: 2
+AccessModifierOffset: -4
 ---

--- a/library/cpp/BUILD
+++ b/library/cpp/BUILD
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+exports_files(["clang_format.sh", ".clang-format"])

--- a/library/cpp/clang_format.sh
+++ b/library/cpp/clang_format.sh
@@ -1,0 +1,12 @@
+differing_count=0
+for f in "${@:2}";do
+  echo "- Checking $f"
+  clang-format -style=file:$1 $f | diff $f -  ;
+  let differing_count+=$?
+  echo "================================================================================"
+done
+echo "Differing files: $differing_count"
+
+exit_code=0
+if [ $differing_count -gt 0 ]; then exit_code=1; fi
+exit $exit_code


### PR DESCRIPTION
## What is the goal of this PR?
Adds rules & dependencies for building C++ targets.

## What are the changes implemented in this PR?
* Adds dependencies for the C++ typedb-driver
  - Gherkin, for parsing gherkin BDD feature files in C++
  - Cucumber messages, for the C++ representation of the gherkin language. 
  - A json (`nlohmann/json`) library which is in the dependencies for cucumber messages, gherkin & building the C++ driver.
* Adds the `clang_format_test` target type for ensuring C++ style compliance.