### PR TITLE
Update protobuf version to align with io.grpc

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -56,7 +56,7 @@ artifacts = {
     "com.google.ortools:ortools-linux-x86-64": "9.6.2534",
     "com.google.ortools:ortools-linux-aarch64": "9.6.2534",
     "com.google.ortools:ortools-win32-x86-64": "9.6.2534",
-    "com.google.protobuf:protobuf-java": "3.20.1",
+    "com.google.protobuf:protobuf-java": "3.21.7",
     "com.google.re2j:re2j" : "1.6",
     "com.google.truth:truth" : "1.0.1",
     "com.jcraft:jsch": "0.1.55",


### PR DESCRIPTION
## What is the goal of this PR?

We update the version of Java com.google.protobuf library to align with the version referred to by the Bazel distribution of io.grpc.