### PR TITLE
Move typedb_java_test rule to dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+*.bat   text eol=crlf
+
+

--- a/builder/java/BUILD
+++ b/builder/java/BUILD
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+filegroup(
+    name = "logback",
+    srcs = ["logback.xml"],
+    visibility = ["//visibility:public"],
+)

--- a/builder/java/logback.xml
+++ b/builder/java/logback.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (C) 2022 Vaticle
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/builder/java/rules.bzl
+++ b/builder/java/rules.bzl
@@ -140,7 +140,7 @@ def typedb_java_test(name, server_artifacts, console_artifacts = {},
     native.java_test(
         name = name,
         deps = depset(deps).to_list() + native_dependencies,
-        classpath_resources = depset(classpath_resources).to_list(),
+        classpath_resources = depset(classpath_resources + ["@vaticle_dependencies//builder/java:logback"]).to_list(),
         data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
         args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
         **kwargs

--- a/builder/java/rules.bzl
+++ b/builder/java/rules.bzl
@@ -1,3 +1,22 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
 def _expand_label(name):
     """
     Expands incomplete labels without target names into full ones, e.g.:
@@ -111,3 +130,62 @@ def native_dep_for_host_platform(name):
          "@vaticle_bazel_distribution//platform:is_windows": [name + "-windows"],
          "//conditions:default": ["INVALID"],
      })
+
+def typedb_java_test(name, server_artifacts, console_artifacts = {},
+                      native_libraries_deps = [], deps = [], classpath_resources = [], data = [], args = [], **kwargs):
+    native_server_artifact_paths, native_server_artifact_labels = native_artifact_paths_and_labels(server_artifacts)
+    native_console_artifact_paths, native_console_artifact_labels = native_artifact_paths_and_labels(console_artifacts, mandatory = False)
+    native_dependencies = get_native_dependencies(native_libraries_deps)
+
+    native.java_test(
+        name = name,
+        deps = depset(deps).to_list() + native_dependencies,
+        classpath_resources = depset(classpath_resources).to_list(),
+        data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
+        args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
+        **kwargs
+    )
+
+def typedb_kt_test(name, server_artifacts, console_artifacts = {},
+                        native_libraries_deps = [], deps = [], data = [], args = [], **kwargs):
+    native_server_artifact_paths, native_server_artifact_labels = native_artifact_paths_and_labels(server_artifacts)
+    native_console_artifact_paths, native_console_artifact_labels = native_artifact_paths_and_labels(console_artifacts, mandatory = False)
+    native_dependencies = get_native_dependencies(native_libraries_deps)
+
+    kt_jvm_test(
+        name = name,
+        deps = depset(deps).to_list() + native_dependencies,
+        data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
+        args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
+        **kwargs
+    )
+
+def get_native_dependencies(native_libraries_deps):
+    native_dependencies = []
+    for dep in native_libraries_deps:
+       native_dependencies = native_dependencies + native_dep_for_host_platform(dep)
+    return native_dependencies
+
+
+def native_artifact_paths_and_labels(native_artifacts, mandatory = True):
+    if native_artifacts:
+        native_artifact_paths = {}
+        native_artifact_labels = {}
+        for key in native_artifacts.keys():
+            native_artifact_labels[key] = [ native_artifacts[key] ]
+            native_artifact_paths[key] = [ "$(location {})".format(native_artifacts[key]) ]
+        return native_artifact_paths, native_artifact_labels
+    elif mandatory:
+        fail("Mandatory artifacts weren't available.")
+    else:
+        return [], []
+
+
+def native_typedb_artifact(name, native_artifacts, output, **kwargs):
+    native.genrule(
+        name = name,
+        outs = [output],
+        srcs = select(native_artifacts, no_match_error = "There is no TypeDB artifact compatible with this operating system."),
+        cmd = "read -a srcs <<< '$(SRCS)' && read -a outs <<< '$(OUTS)' && cp $${srcs[0]} $${outs[0]} && echo $${outs[0]}",
+        **kwargs
+    )

--- a/builder/java/rules.bzl
+++ b/builder/java/rules.bzl
@@ -139,7 +139,7 @@ def typedb_java_test(name, server_artifacts, console_artifacts = {},
 
     native.java_test(
         name = name,
-        deps = depset(deps).to_list() + native_dependencies,
+        deps = deps + native_dependencies,
         classpath_resources = depset(classpath_resources + ["@vaticle_dependencies//builder/java:logback"]).to_list(),
         data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
         args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
@@ -154,7 +154,7 @@ def typedb_kt_test(name, server_artifacts, console_artifacts = {},
 
     kt_jvm_test(
         name = name,
-        deps = depset(deps).to_list() + native_dependencies,
+        deps = deps + native_dependencies,
         data = data + select(native_server_artifact_labels) + (select(native_console_artifact_labels) if native_console_artifact_labels else []),
         args = ["--server"] + select(native_server_artifact_paths) + ((["--console"] + select(native_console_artifact_paths)) if native_console_artifact_paths else []) + args,
         **kwargs

--- a/library/maven/rules.bzl
+++ b/library/maven/rules.bzl
@@ -2,7 +2,7 @@ load("@rules_jvm_external//:defs.bzl", rje_maven_install = "maven_install")
 load("@rules_jvm_external//:specs.bzl", rje_maven = "maven", rje_parse = "parse")
 load(":artifacts.bzl", maven_artifacts_org = "artifacts")
 
-def maven(artifacts_org, artifacts_repo={}, override_targets={}, fail_on_missing_checksum=True, generate_compat_repositories=False):
+def maven(artifacts_org, internal_artifacts = {}, artifacts_repo={}, override_targets={}, fail_on_missing_checksum=True, generate_compat_repositories=False):
     if len(artifacts_repo) > 0:
         _warn("There are {} artifacts_repo found. Overriding artifacts_org with `artifacts_repo` is discouraged!".format(len(artifacts_repo)))
     for a in artifacts_org:
@@ -12,6 +12,10 @@ def maven(artifacts_org, artifacts_repo={}, override_targets={}, fail_on_missing
     for a in artifacts_org:
         artifact = maven_artifact(a, artifacts_repo.get(a, maven_artifacts_org[a]))
         artifacts_selected.append(artifact)
+    for coordinate, info in internal_artifacts.items():
+        if not coordinate.startswith("com.vaticle."):
+            fail("'" + coordinate + "' is not an internal dependency and must be declared in @vaticle_dependencies")
+        artifacts_selected.append(maven_artifact(coordinate, info))
     rje_maven_install(
         artifacts = artifacts_selected,
         repositories = [


### PR DESCRIPTION
## What is the goal of this PR?

Move TypeDB test helper rules from typedb-common to dependencies.

## What are the changes implemented in this PR?

The `maven()` rule receives an additional `internal_artifacts` argument so we can depend on internal maven dependencies without pinning them additionally in this repository.