### PR TITLE
Add doxygen rules for cpp driver docs generation

### DIFF
--- a/builder/cpp/rules.bzl
+++ b/builder/cpp/rules.bzl
@@ -68,3 +68,89 @@ clang_format_test = rule(
         ),
     },
 )
+
+def _doxygen_docs_impl(ctx):
+    output_directory = ctx.actions.declare_directory(ctx.attr._output_directory)
+    files = []
+    for target in ctx.attr.sources:
+        files.extend(target.files.to_list())
+
+    replacements = {
+        "PROJECT_NAME": ctx.attr.project_name,
+        "OUTPUT_DIRECTORY" : output_directory.path
+    }
+    if ctx.attr.strip_from_path != None:
+            replacements["STRIP_FROM_PATH"] =ctx.attr.strip_from_path
+
+    if ctx.file.main_page_md != None:
+        files.add(ctx.file.main_page_md)
+        replacements["USE_MDFILE_AS_MAINPAGE"] = ctx.file.main_page_md.path
+
+    replacements["INPUT"] = " ".join([f.path for f in files])
+
+    # Prepare doxyfile replacements
+    replacements_file = ctx.actions.declare_file("%s.replacements" % ctx.attr.name)
+    ctx.actions.write(
+        output = replacements_file,
+        content = "\n".join([(k + " = " +replacements[k]) for k in replacements]),
+        is_executable = False,
+    )
+
+    # Prepare doxyfile
+    doxyfile = ctx.actions.declare_file("%s.doxyfile" % ctx.attr.name)
+    ctx.actions.run(
+        inputs = [ctx.file._templater_script, ctx.file._doxyfile_template, replacements_file],
+        outputs = [doxyfile],
+        arguments = [ctx.file._templater_script.path, ctx.file._doxyfile_template.path, replacements_file.path, doxyfile.path],
+        executable = "python3",
+        use_default_shell_env = True
+    )
+    files = [doxyfile] + files
+    print(doxyfile.path)
+    ctx.actions.run(
+        inputs = files,
+        outputs = [output_directory],
+        arguments = [doxyfile.path],
+        executable = "doxygen",
+        use_default_shell_env = True
+    )
+
+    return DefaultInfo(files = depset([output_directory]))
+
+doxygen_docs = rule(
+    implementation = _doxygen_docs_impl,
+    test = False,
+    attrs = {
+        "project_name" : attr.string(
+            doc = "The project name for the doxygen docs",
+            mandatory = True,
+        ),
+        "sources" : attr.label_list(
+            doc = "A list of files made available to doxygen. This is NOT automatically included in the doxyfile",
+            mandatory = True,
+            allow_files = True,
+        ),
+        "strip_from_path" : attr.string(
+            doc = "Prefix to strip from path of files being processed",
+            mandatory = False
+        ),
+        "main_page_md" : attr.label(
+            doc = "The file to use as main page for the generate docs",
+            allow_single_file = True,
+            mandatory = False
+        ),
+        "_doxyfile_template" : attr.label(
+             doc = "A template for the doxygen configuration file.",
+             allow_single_file = True,
+             default = "//library/cpp:doxyfile.template"
+         ),
+         "_output_directory" : attr.string(
+             doc = "The output directory for the doxygen docs",
+             default = "doxygen_docs"
+         ),
+         "_templater_script": attr.label(
+             default = "//library/cpp:doxyfile_templater.py",
+             allow_single_file = True,
+         )
+    },
+)

--- a/builder/cpp/rules.bzl
+++ b/builder/cpp/rules.bzl
@@ -83,7 +83,7 @@ def _doxygen_docs_impl(ctx):
             replacements["STRIP_FROM_PATH"] =ctx.attr.strip_from_path
 
     if ctx.file.main_page_md != None:
-        files.add(ctx.file.main_page_md)
+        files.append(ctx.file.main_page_md)
         replacements["USE_MDFILE_AS_MAINPAGE"] = ctx.file.main_page_md.path
 
     replacements["INPUT"] = " ".join([f.path for f in files])

--- a/library/cpp/BUILD
+++ b/library/cpp/BUILD
@@ -14,4 +14,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-exports_files(["clang_format.sh", ".clang-format"])
+exports_files(["clang_format.sh", ".clang-format", "doxyfile.template", "doxyfile_templater.py"])

--- a/library/cpp/doxyfile.template
+++ b/library/cpp/doxyfile.template
@@ -31,6 +31,7 @@ ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 
 BRIEF_MEMBER_DESC      = YES
+ALWAYS_DETAILED_SEC    = YES
 REPEAT_BRIEF           = YES
 STRIP_FROM_PATH        = ## <bazel rule MAY replace this line>
 INHERIT_DOCS           = YES

--- a/library/cpp/doxyfile.template
+++ b/library/cpp/doxyfile.template
@@ -1,0 +1,185 @@
+# Doxyfile 1.9.8
+
+# This file describes the settings to be used by the documentation system
+# doxygen (www.doxygen.org) for a project.
+#
+# All text after a double hash (##) is considered a comment and is placed in
+# front of the TAG it is preceding.
+#
+# All text after a single hash (#) is considered a comment and will be ignored.
+# The format is:
+# TAG = value [value, ...]
+# For lists, items can also be appended using:
+# TAG += value [value, ...]
+# Values that contain spaces should be placed between quotes (\" \").
+#---------------------------------------------------------------------------
+# NOTE:
+# This file has been cleaned up for doxygen doc generation via bazel
+# To see all the options, generate a fresh one with
+# `doxygen -g <output-path>`
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = ## <bazel rule MUST replace this line>
+PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+OUTPUT_DIRECTORY       = ## <bazel rule MUST replace this line>
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+STRIP_FROM_PATH        = ## <bazel rule MAY replace this line>
+INHERIT_DOCS           = YES
+
+MARKDOWN_SUPPORT       = YES
+AUTOLINK_SUPPORT       = YES
+FILE_PATTERNS          = *.h *.hpp *.md *.html
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+HIDE_FRIEND_COMPOUNDS  = YES
+SHOW_HEADERFILE        = NO             ## Show which header to include
+SHOW_INCLUDE_FILES     = NO
+SORT_BRIEF_DOCS        = NO             ## NO: The short description at the top is in declaration order
+SORT_MEMBER_DOCS       = YES            ## YES: The longer description which follows is sorted alphabetically
+SORT_BY_SCOPE_NAME     = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
+WARN_NO_PARAMDOC       = YES
+WARN_IF_UNDOC_ENUM_VAL = YES
+WARN_AS_ERROR          = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = # THIS_LINE_GETS_REPLACED_BY_THE_BAZEL_RULE
+INPUT_ENCODING         = UTF-8
+RECURSIVE              = NO             ## Bazel explicitly specifies files
+EXCLUDE_SYMLINKS       = YES
+USE_MDFILE_AS_MAINPAGE = ## <bazel rule MAY replace this line>
+VERBATIM_HEADERS       = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_COLORSTYLE        = AUTO_LIGHT
+
+ENUM_VALUES_PER_LINE   = 4
+OBFUSCATE_EMAILS       = YES
+SEARCHENGINE           = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to diagram generator tools
+#---------------------------------------------------------------------------
+HIDE_UNDOC_RELATIONS   = YES
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES        ## TODO: Revisit
+GROUP_GRAPHS           = NO
+UML_LIMIT_NUM_FIELDS   = 10
+HAVE_DOT               = NO         ## Disables a bunch of stuff we're not interested in anyway
+
+
+#---------------------------------------------------------------------------
+# TODO: Everything below this point
+#---------------------------------------------------------------------------
+
+# If the ALWAYS_DETAILED_SEC and REPEAT_BRIEF tags are both set to YES then
+# doxygen will generate a detailed section even if there is only a brief
+# description.
+# The default value is: NO.
+ALWAYS_DETAILED_SEC    = NO
+
+# If the INLINE_INHERITED_MEMB tag is set to YES, doxygen will show all
+# inherited members of a class in the documentation of that class as if those
+# members were ordinary class members. Constructors, destructors and assignment
+# operators of the base classes will not be shown.
+# The default value is: NO.
+
+INLINE_INHERITED_MEMB  = NO
+
+# If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
+# to include (a tag file for) the STL sources as input, then you should set this
+# tag to YES in order to let doxygen match functions declarations and
+# definitions whose arguments contain STL classes (e.g. func(std::string);
+# versus func(std::string) {}). This also make the inheritance and collaboration
+# diagrams that involve STL classes more complete and accurate.
+# The default value is: NO.
+
+BUILTIN_STL_SUPPORT    = NO
+
+
+# If the TIMESTAMP tag is set different from NO then each generated page will
+# contain the date or date and time when the page was generated. Setting this to
+# NO can help when comparing the output of multiple runs.
+# Possible values are: YES, NO, DATETIME and DATE.
+# The default value is: NO.
+
+TIMESTAMP              = NO
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+
+# If the EXTRACT_ALL tag is set to YES, doxygen will assume all entities in
+# documentation are documented, even if no documentation was available. Private
+# class members and static file members will be hidden unless the
+# EXTRACT_PRIVATE respectively EXTRACT_STATIC tags are set to YES.
+# Note: This will also disable the warnings about undocumented members that are
+# normally produced when WARNINGS is set to YES.
+# The default value is: NO.
+
+EXTRACT_ALL            = NO
+#...
+
+# If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
+# included in the documentation.
+# The default value is: NO.
+
+EXTRACT_STATIC         = NO
+
+# If the SORT_MEMBER_DOCS tag is set to YES then doxygen will sort the
+# (detailed) documentation of file and class members alphabetically by member
+# name. If set to NO, the members will appear in declaration order.
+# The default value is: YES.
+
+# The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
+# by doxygen. The layout file controls the global structure of the generated
+# output files in an output format independent way. To create the layout file
+# that represents doxygen's defaults, run doxygen with the -l option. You can
+# optionally specify a file name after the option, if omitted DoxygenLayout.xml
+# will be used as the name of the layout file. See also section "Changing the
+# layout of pages" for information.
+#
+# Note that if you run doxygen from a directory containing a file called
+# DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
+# tag is left empty.
+
+LAYOUT_FILE            =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+# The IMAGE_PATH tag can be used to specify one or more files or directories
+# that contain images that are to be included in the documentation (see the
+# \image command).
+IMAGE_PATH             =

--- a/library/cpp/doxyfile.template
+++ b/library/cpp/doxyfile.template
@@ -35,6 +35,7 @@ ALWAYS_DETAILED_SEC    = YES
 REPEAT_BRIEF           = YES
 STRIP_FROM_PATH        = ## <bazel rule MAY replace this line>
 INHERIT_DOCS           = YES
+INLINE_INHERITED_MEMB  = NO
 
 MARKDOWN_SUPPORT       = YES
 AUTOLINK_SUPPORT       = YES
@@ -96,102 +97,3 @@ GENERATE_LATEX         = NO
 HIDE_UNDOC_RELATIONS   = YES
 CLASS_GRAPH            = YES
 HAVE_DOT               = NO             ## Disables many details
-
-#---------------------------------------------------------------------------
-# TODO: Everything below this point
-#---------------------------------------------------------------------------
-
-# If the ALWAYS_DETAILED_SEC and REPEAT_BRIEF tags are both set to YES then
-# doxygen will generate a detailed section even if there is only a brief
-# description.
-# The default value is: NO.
-ALWAYS_DETAILED_SEC    = NO
-
-# If the INLINE_INHERITED_MEMB tag is set to YES, doxygen will show all
-# inherited members of a class in the documentation of that class as if those
-# members were ordinary class members. Constructors, destructors and assignment
-# operators of the base classes will not be shown.
-# The default value is: NO.
-
-INLINE_INHERITED_MEMB  = NO
-
-# If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
-# to include (a tag file for) the STL sources as input, then you should set this
-# tag to YES in order to let doxygen match functions declarations and
-# definitions whose arguments contain STL classes (e.g. func(std::string);
-# versus func(std::string) {}). This also make the inheritance and collaboration
-# diagrams that involve STL classes more complete and accurate.
-# The default value is: NO.
-
-BUILTIN_STL_SUPPORT    = NO
-
-
-# If the TIMESTAMP tag is set different from NO then each generated page will
-# contain the date or date and time when the page was generated. Setting this to
-# NO can help when comparing the output of multiple runs.
-# Possible values are: YES, NO, DATETIME and DATE.
-# The default value is: NO.
-
-TIMESTAMP              = NO
-
-#---------------------------------------------------------------------------
-# Build related configuration options
-#---------------------------------------------------------------------------
-
-# If the EXTRACT_ALL tag is set to YES, doxygen will assume all entities in
-# documentation are documented, even if no documentation was available. Private
-# class members and static file members will be hidden unless the
-# EXTRACT_PRIVATE respectively EXTRACT_STATIC tags are set to YES.
-# Note: This will also disable the warnings about undocumented members that are
-# normally produced when WARNINGS is set to YES.
-# The default value is: NO.
-
-EXTRACT_ALL            = NO
-#...
-
-# If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
-# included in the documentation.
-# The default value is: NO.
-
-EXTRACT_STATIC         = NO
-
-# If the SORT_MEMBER_DOCS tag is set to YES then doxygen will sort the
-# (detailed) documentation of file and class members alphabetically by member
-# name. If set to NO, the members will appear in declaration order.
-# The default value is: YES.
-
-# The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
-# by doxygen. The layout file controls the global structure of the generated
-# output files in an output format independent way. To create the layout file
-# that represents doxygen's defaults, run doxygen with the -l option. You can
-# optionally specify a file name after the option, if omitted DoxygenLayout.xml
-# will be used as the name of the layout file. See also section "Changing the
-# layout of pages" for information.
-#
-# Note that if you run doxygen from a directory containing a file called
-# DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
-# tag is left empty.
-
-LAYOUT_FILE            =
-
-#---------------------------------------------------------------------------
-# Configuration options related to the input files
-#---------------------------------------------------------------------------
-# The IMAGE_PATH tag can be used to specify one or more files or directories
-# that contain images that are to be included in the documentation (see the
-# \image command).
-IMAGE_PATH             =
-
-# UML
-
-# If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
-# graph for each documented class showing the direct and indirect implementation
-# dependencies (inheritance, containment, and class references variables) of the
-# class with other documented classes. Explicit enabling a collaboration graph,
-# when COLLABORATION_GRAPH is set to NO, can be accomplished by means of the
-# command \collaborationgraph. Disabling a collaboration graph can be
-# accomplished by means of the command \hidecollaborationgraph.
-# The default value is: YES.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-# COLLABORATION_GRAPH    = YES ## Already in the

--- a/library/cpp/doxyfile.template
+++ b/library/cpp/doxyfile.template
@@ -23,8 +23,8 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = ## <bazel rule MUST replace this line>
-PROJECT_NUMBER         =
-PROJECT_BRIEF          =
+PROJECT_NUMBER         = ## <bazel rule MAY replace this line>
+PROJECT_BRIEF          =                ## If we ever want a description
 OUTPUT_DIRECTORY       = ## <bazel rule MUST replace this line>
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
@@ -64,10 +64,10 @@ WARN_AS_ERROR          = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = # THIS_LINE_GETS_REPLACED_BY_THE_BAZEL_RULE
+INPUT                  = ## <bazel rule MUST replace this line>
 INPUT_ENCODING         = UTF-8
-RECURSIVE              = NO             ## Bazel explicitly specifies files
-EXCLUDE_SYMLINKS       = YES
+RECURSIVE              = NO             ## bazel explicitly specifies files
+EXCLUDE_SYMLINKS       = NO             ## bazel needs NO
 USE_MDFILE_AS_MAINPAGE = ## <bazel rule MAY replace this line>
 VERBATIM_HEADERS       = YES
 
@@ -83,21 +83,18 @@ GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
 HTML_COLORSTYLE        = AUTO_LIGHT
-
 ENUM_VALUES_PER_LINE   = 4
 OBFUSCATE_EMAILS       = YES
 SEARCHENGINE           = YES
+
+GENERATE_LATEX         = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to diagram generator tools
 #---------------------------------------------------------------------------
 HIDE_UNDOC_RELATIONS   = YES
 CLASS_GRAPH            = YES
-COLLABORATION_GRAPH    = YES        ## TODO: Revisit
-GROUP_GRAPHS           = NO
-UML_LIMIT_NUM_FIELDS   = 10
-HAVE_DOT               = NO         ## Disables a bunch of stuff we're not interested in anyway
-
+HAVE_DOT               = NO             ## Disables many details
 
 #---------------------------------------------------------------------------
 # TODO: Everything below this point
@@ -183,3 +180,17 @@ LAYOUT_FILE            =
 # that contain images that are to be included in the documentation (see the
 # \image command).
 IMAGE_PATH             =
+
+# UML
+
+# If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
+# graph for each documented class showing the direct and indirect implementation
+# dependencies (inheritance, containment, and class references variables) of the
+# class with other documented classes. Explicit enabling a collaboration graph,
+# when COLLABORATION_GRAPH is set to NO, can be accomplished by means of the
+# command \collaborationgraph. Disabling a collaboration graph can be
+# accomplished by means of the command \hidecollaborationgraph.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+# COLLABORATION_GRAPH    = YES ## Already in the

--- a/library/cpp/doxyfile_templater.py
+++ b/library/cpp/doxyfile_templater.py
@@ -1,0 +1,12 @@
+import re
+from sys import argv
+
+with open(argv[1], 'r') as f: contents = f.read()
+with open(argv[2], 'r') as f:
+    for replacement in f:
+        replace = replacement.split("=", 2)
+        regex_str = '^' + replace[0].strip() + '\\s*=.*$'
+        compiled = re.compile(regex_str, re.MULTILINE)
+        contents = compiled.sub(replacement, contents)
+
+with open(argv[3], 'w') as f: f.write(contents)


### PR DESCRIPTION
## What is the goal of this PR?
Adds a bazel rule to generate docs for C++ code using doxygen 

## What are the changes implemented in this PR?
Introduces the rule `doxygen_docs` rule in `//builder/cpp:rules.bzl` 
* Expects doxygen to be present on the system
* Uses a doxyfile template as configuration, And a python script to replace the relevant config lines.
