### PR TITLE
Update target label moved from grpc to proto_grpc

### DIFF
--- a/builder/proto_grpc/rust/compile.bzl
+++ b/builder/proto_grpc/rust/compile.bzl
@@ -56,7 +56,7 @@ rust_tonic_compile = rule(
         "_compile_script": attr.label(
             executable = True,
             cfg = "host",
-            default = "@vaticle_dependencies//builder/grpc/rust:compile",
+            default = "@vaticle_dependencies//builder/proto_grpc/rust:compile",
         ),
     }
 )


### PR DESCRIPTION
## What is the goal of this PR?

We update the `rust_tonic_compile` bazel rule to refer to `//builder/proto_grpc/rust:compile`, which was moved from `//builder/grpc/rust:compile` in #492
