### PR TITLE
Add OutputGroupInfo to cbindgen rule

### DIFF
--- a/builder/rust/rules.bzl
+++ b/builder/rust/rules.bzl
@@ -124,6 +124,9 @@ def _rust_cbindgen_impl(ctx):
             files = depset([output_header], transitive = [rust_lib.files]),
             runfiles = ctx.runfiles([output_header], transitive_files = rust_lib.files),
         ),
+        OutputGroupInfo(
+            header = depset([output_header]),
+        ),
      ]
 
 rust_cbindgen = rule(

--- a/builder/rust/rules.bzl
+++ b/builder/rust/rules.bzl
@@ -124,9 +124,7 @@ def _rust_cbindgen_impl(ctx):
             files = depset([output_header], transitive = [rust_lib.files]),
             runfiles = ctx.runfiles([output_header], transitive_files = rust_lib.files),
         ),
-        OutputGroupInfo(
-            header = depset([output_header]),
-        ),
+        OutputGroupInfo(header = depset([output_header])),
      ]
 
 rust_cbindgen = rule(


### PR DESCRIPTION
## What is the goal of this PR?
Add OutputGroupInfo to cbindgen rule. This makes it easy to reference the header and document the C driver.

## What are the changes implemented in this PR?
Add OutputGroupInfo to cbindgen rule for easy reference to the header file
