### PR TITLE
Bump mailgun java dependency

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -331,4 +331,5 @@ artifacts = {
     "org.zeromq:jeromq": "0.5.2",
     "org.zeroturnaround:zt-exec": "1.10",
     "com.mailgun:mailgun-java": "1.1.2",
+    "io.github.openfeign:feign-core": "13.2.1",
 }

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -330,5 +330,5 @@ artifacts = {
     "org.yaml:snakeyaml": "1.25",
     "org.zeromq:jeromq": "0.5.2",
     "org.zeroturnaround:zt-exec": "1.10",
-    "com.mailgun:mailgun-java": "1.0.8",
+    "com.mailgun:mailgun-java": "1.1.2",
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've bumped a dependency on Mailgun Java and added feign-core, which is a dependency required for the operation of the Mailgun client.

## What are the changes implemented in this PR?

As above.