### PR TITLE
Add version number to the filename when deploying APT packages

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "c473d17530dff5a4398d2de9c9fe966df9aca4ce" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "fbec2a325fa7afa5125d80846218dcb8e4f57e2f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?
Bumps bazel-distribution to Include a fix adding the version number to the filename when deploying APT packages.

## What are the changes implemented in this PR?
Bumps bazel-distribution to Include a fix adding the version number to the filename when deploying APT packages.
