### PR TITLE
Update cucumber BDD dependencies for C++

### DIFF
--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -10,15 +10,15 @@ def deps():
 
     http_archive(
         name = "gherkin_cpp",
-        urls = ["https://github.com/vaticle/gherkin/archive/19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8.zip"],
-        strip_prefix = "gherkin-19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8/cpp",
-        sha256 = "f8fd8d46b384a3c27a3bfed0e5eb1ad4ae2dbac862b18153a76178ec35a2c459",
+        urls = ["https://github.com/cucumber/gherkin/archive/refs/tags/v28.0.0.zip"],
+        strip_prefix = "gherkin-28.0.0/cpp",
+        sha256 = "30eba0790c3aafeea5be25e5e4bf1e0628bc9546539227c0a793987f87eca6a1",
         build_file_content = """
 cc_library(
   name = "gherkin-lib",
   deps = ["@nlohmann_json//:json", "@cucumber_messages//:cucumber-messages-lib"],
   hdrs = glob(["include/**/*.hpp"]),
-  strip_include_prefix = "include",
+  strip_include_prefix = "include/gherkin",
   srcs = glob(["src/lib/gherkin/**/*.cpp"]),
   copts = ["--std=c++17"],
   visibility= ["//visibility:public"],
@@ -28,15 +28,15 @@ cc_library(
 
     http_archive(
         name = "cucumber_messages",
-        urls = ["https://github.com/vaticle/cucumber-messages/archive/fc5c391add237b0d5fa090072757a500863c24b7.zip"],
-        strip_prefix = "cucumber-messages-fc5c391add237b0d5fa090072757a500863c24b7/cpp",
-        sha256 = "048a04c8b1163f601dc8992d41f3254a5ce58ac487514ee4ddd06090aa666d25",
+        urls = ["https://github.com/cucumber/messages/archive/refs/tags/v24.1.0.zip"],
+        strip_prefix = "messages-24.1.0/cpp",
+        sha256 = "90922751ec690b2a561303d2e5a0d330dfb7a8c82b36a672820b8dca1be12452",
         build_file_content = """
 cc_library(
   name = "cucumber-messages-lib",
   deps = ["@nlohmann_json//:json"],
   hdrs = glob(["include/**/*.hpp"]),
-  strip_include_prefix = "include",
+  strip_include_prefix = "include/messages",
   srcs = glob(["src/lib/cucumber-messages/**/*.cpp", "src/lib/cucumber-messages/**/*.hpp"]),
   copts = [
     "--std=c++17",


### PR DESCRIPTION
## What is the goal of this PR?
Update cucumber BDD dependencies for C++

## What are the changes implemented in this PR?
We depended on our own fork of cucumber-messages & gherkin because we had to add a fix for clang. 
The changes have since made it into the upstream repositories, so we update the dependencies to point back to them.
