### PR TITLE
Logback-contrib libraries

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -2,6 +2,8 @@ artifacts = {
     "androidx.annotation:annotation": "1.2.0",
     "ch.qos.logback:logback-classic": "1.4.9",
     "ch.qos.logback:logback-core": "1.4.9",
+    "ch.qos.logback.contrib:logback-json-classic" : "0.1.5",
+    "ch.qos.logback.contrib:logback-json-core" : "0.1.5",
     "com.auth0:java-jwt": "3.8.3",
     "com.azure:azure-core": "1.5.0",
     "com.azure:azure-identity": "1.0.6",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -4,6 +4,7 @@ artifacts = {
     "ch.qos.logback:logback-core": "1.4.9",
     "ch.qos.logback.contrib:logback-json-classic" : "0.1.5",
     "ch.qos.logback.contrib:logback-json-core" : "0.1.5",
+    "ch.qos.logback.contrib:logback-jackson" : "0.1.5",
     "com.auth0:java-jwt": "3.8.3",
     "com.azure:azure-core": "1.5.0",
     "com.azure:azure-identity": "1.0.6",


### PR DESCRIPTION
## What is the goal of this PR?
We need to add "ch.qos.logback.contrib:logback-json-classic | logback-json-core | logback-jackson" for TypeDB Platform to integrate with GCP Structured Logging
## What are the changes implemented in this PR?
As above