### PR TITLE
Update JSON dependency used by C++ cucumber BDD

### DIFF
--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -53,9 +53,9 @@ cc_library(
 
     http_archive(
         name = "nlohmann_json",
-        urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip"],
-        strip_prefix = "json-3.11.2",
-        sha256 = "95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9",
+        urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip"],
+        strip_prefix = "json-3.11.3",
+        sha256 = "04022b05d806eb5ff73023c280b68697d12b93e1b7267a0b22a1a39ec7578069",
         build_file_content = """
 cc_library(
   name = "json",


### PR DESCRIPTION
## What is the goal of this PR?
Update cucumber BDD dependencies for C++

## What are the changes implemented in this PR?
#517 missed updating the dependency to `nlohmann/json`. Though the previous version works fine on a Mac, it does not link on linux. This PR updates the dependency to that expected by cucumber.