### PR TITLE
Revert updates to C++ dependencies

### DIFF
--- a/builder/cpp/deps.bzl
+++ b/builder/cpp/deps.bzl
@@ -14,15 +14,15 @@ def deps():
 
     http_archive(
         name = "gherkin_cpp",
-        urls = ["https://github.com/cucumber/gherkin/archive/refs/tags/v28.0.0.zip"],
-        strip_prefix = "gherkin-28.0.0/cpp",
-        sha256 = "30eba0790c3aafeea5be25e5e4bf1e0628bc9546539227c0a793987f87eca6a1",
+        urls = ["https://github.com/vaticle/gherkin/archive/19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8.zip"],
+        strip_prefix = "gherkin-19b7ca13da8bb4cb6dc27ef5af572a8a1233deb8/cpp",
+        sha256 = "f8fd8d46b384a3c27a3bfed0e5eb1ad4ae2dbac862b18153a76178ec35a2c459",
         build_file_content = """
 cc_library(
   name = "gherkin-lib",
   deps = ["@nlohmann_json//:json", "@cucumber_messages//:cucumber-messages-lib"],
   hdrs = glob(["include/**/*.hpp"]),
-  strip_include_prefix = "include/gherkin",
+  strip_include_prefix = "include",
   srcs = glob(["src/lib/gherkin/**/*.cpp"]),
   copts = ["--std=c++17"],
   visibility= ["//visibility:public"],
@@ -32,15 +32,15 @@ cc_library(
 
     http_archive(
         name = "cucumber_messages",
-        urls = ["https://github.com/cucumber/messages/archive/refs/tags/v24.1.0.zip"],
-        strip_prefix = "messages-24.1.0/cpp",
-        sha256 = "90922751ec690b2a561303d2e5a0d330dfb7a8c82b36a672820b8dca1be12452",
+        urls = ["https://github.com/vaticle/cucumber-messages/archive/fc5c391add237b0d5fa090072757a500863c24b7.zip"],
+        strip_prefix = "cucumber-messages-fc5c391add237b0d5fa090072757a500863c24b7/cpp",
+        sha256 = "048a04c8b1163f601dc8992d41f3254a5ce58ac487514ee4ddd06090aa666d25",
         build_file_content = """
 cc_library(
   name = "cucumber-messages-lib",
   deps = ["@nlohmann_json//:json"],
   hdrs = glob(["include/**/*.hpp"]),
-  strip_include_prefix = "include/messages",
+  strip_include_prefix = "include",
   srcs = glob(["src/lib/cucumber-messages/**/*.cpp", "src/lib/cucumber-messages/**/*.hpp"]),
   copts = [
     "--std=c++17",
@@ -53,9 +53,9 @@ cc_library(
 
     http_archive(
         name = "nlohmann_json",
-        urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip"],
-        strip_prefix = "json-3.11.3",
-        sha256 = "04022b05d806eb5ff73023c280b68697d12b93e1b7267a0b22a1a39ec7578069",
+        urls = ["https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip"],
+        strip_prefix = "json-3.11.2",
+        sha256 = "95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9",
         build_file_content = """
 cc_library(
   name = "json",


### PR DESCRIPTION
## What is the goal of this PR?
Revert updates to C++ dependencies 

## What are the changes implemented in this PR?
Reverts the changes made in  #522 and #517  since gherkin & cucumber messages seem to be out of sync, causing linux builds to fail.
