### PR TITLE
Open PR tool

### DIFF
--- a/tool/common/deps.bzl
+++ b/tool/common/deps.bzl
@@ -17,6 +17,8 @@ maven_artifacts = [
   "com.google.http-client:google-http-client",
   "org.zeroturnaround:zt-exec",
   "info.picocli:picocli",
+  "commons-io:commons-io",
+  "org.kohsuke:github-api",
   "org.jetbrains.compose.compiler:compiler",
   "org.jsoup:jsoup",
 ]

--- a/tool/github/BUILD
+++ b/tool/github/BUILD
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+kt_jvm_library(
+    name = "open-pr-jar",
+    srcs = glob(["*.kt"]),
+    data = glob(["template/**/*"]),
+    deps = [
+        "@vaticle_bazel_distribution//common",
+        "@vaticle_bazel_distribution//common/shell",
+        "@maven//:org_zeroturnaround_zt_exec",
+        "@maven//:commons_io_commons_io",
+        "@maven//:info_picocli_picocli",
+        "@maven//:org_kohsuke_github_api",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+java_binary(
+    name = "open-pr",
+    runtime_deps = ["open-pr-jar"],
+    main_class = "com.vaticle.dependencies.tool.github.OpenPR",
+    visibility = ["//visibility:public"],
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "mpl-header",
+)

--- a/tool/github/OpenPR.kt
+++ b/tool/github/OpenPR.kt
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.vaticle.dependencies.tool.github
+
+import picocli.CommandLine
+import java.util.concurrent.Callable
+import kotlin.system.exitProcess
+
+object OpenPR: Callable<Int> {
+    @CommandLine.Option(names = ["--repo"], description = ["The repository to open the PR on"])
+    private lateinit var repo: String
+
+    @CommandLine.Option(names = ["--head-branch"], description = ["The merging branch"])
+    private lateinit var headBranch: String
+
+    @CommandLine.Option(names = ["--base-branch"], description = ["The branch being merged into"])
+    private lateinit var baseBranch: String
+
+    @CommandLine.Option(names = ["--title"], description = ["The title of the PR"])
+    private lateinit var title: String
+
+    @CommandLine.Option(names = ["--token"], description = ["The GitHub authentication token"])
+    private lateinit var token: String
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        exitProcess(CommandLine(OpenPR).execute(*args))
+    }
+
+    override fun call(): Int {
+        return 0
+    }
+}

--- a/tool/github/OpenPR.kt
+++ b/tool/github/OpenPR.kt
@@ -6,6 +6,7 @@
 
 package com.vaticle.dependencies.tool.github
 
+import org.kohsuke.github.GitHub
 import picocli.CommandLine
 import java.util.concurrent.Callable
 import kotlin.system.exitProcess
@@ -23,8 +24,13 @@ object OpenPR: Callable<Int> {
     @CommandLine.Option(names = ["--title"], description = ["The title of the PR"])
     private lateinit var title: String
 
+    @CommandLine.Option(names = ["--title"], description = ["The body of the PR"])
+    private lateinit var body: String
+
     @CommandLine.Option(names = ["--token"], description = ["The GitHub authentication token"])
     private lateinit var token: String
+
+    private const val USERNAME = "vaticle-bot"
 
     @JvmStatic
     fun main(args: Array<String>) {
@@ -32,6 +38,8 @@ object OpenPR: Callable<Int> {
     }
 
     override fun call(): Int {
+        val gh = GitHub.connect(USERNAME, token)
+        gh.getRepository(repo).createPullRequest(title, headBranch, baseBranch, body)
         return 0
     }
 }

--- a/tool/github/OpenPR.kt
+++ b/tool/github/OpenPR.kt
@@ -12,6 +12,8 @@ import java.util.concurrent.Callable
 import kotlin.system.exitProcess
 
 object OpenPR: Callable<Int> {
+    private const val DEFAULT_USERNAME = "vaticle-bot"
+
     @CommandLine.Option(names = ["--repo"], description = ["The repository to open the PR on"])
     private lateinit var repo: String
 
@@ -25,12 +27,13 @@ object OpenPR: Callable<Int> {
     private lateinit var title: String
 
     @CommandLine.Option(names = ["--body"], description = ["The body of the PR"])
-    private lateinit var body: String
+    private var body: String = ""
+
+    @CommandLine.Option(names = ["--username"], description = ["The GitHub username of the user opening the PR"])
+    private var username: String = DEFAULT_USERNAME
 
     @CommandLine.Option(names = ["--token"], description = ["The GitHub authentication token"])
     private lateinit var token: String
-
-    private const val USERNAME = "vaticle-bot"
 
     @JvmStatic
     fun main(args: Array<String>) {
@@ -38,7 +41,7 @@ object OpenPR: Callable<Int> {
     }
 
     override fun call(): Int {
-        val gh = GitHub.connect(USERNAME, token)
+        val gh = GitHub.connect(username, token)
         gh.getRepository(repo).createPullRequest(title, headBranch, baseBranch, body)
         return 0
     }

--- a/tool/github/OpenPR.kt
+++ b/tool/github/OpenPR.kt
@@ -24,7 +24,7 @@ object OpenPR: Callable<Int> {
     @CommandLine.Option(names = ["--title"], description = ["The title of the PR"])
     private lateinit var title: String
 
-    @CommandLine.Option(names = ["--title"], description = ["The body of the PR"])
+    @CommandLine.Option(names = ["--body"], description = ["The body of the PR"])
     private lateinit var body: String
 
     @CommandLine.Option(names = ["--token"], description = ["The GitHub authentication token"])


### PR DESCRIPTION
## What is the goal of this PR?

We've created a tool that can be used to open a PR on GitHub. Now, programatically creating PRs is possible and convenient.

## What are the changes implemented in this PR?

As above.

## Example usage
```
bazel run @vaticle_dependencies//tool/github:open-pr -- \
  --repo=vaticle/typedb \
  --head-branch=development \
  --base-branch=master \
  --title="Release" \
  --body="Replace me" \
  --token=$GITHUB_TOKEN
```

## Defaults
By default, we provide an empty body for the PR and 'vaticle-bot' for the username.