### PR TITLE
JaCoCo dependencies and Sonar tool improvements

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -328,6 +328,7 @@ artifacts = {
     "org.jetbrains.kotlinx:kotlinx-coroutines-test": "1.7.3",
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": "1.6.2",
     "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm": "1.6.2",
+    "org.jetbrains.kotlinx:kover-jvm-agent": "0.8.0-Beta2",
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.85",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -331,6 +331,7 @@ artifacts = {
     "org.jetbrains.kotlinx:kover-jvm-agent": "0.8.0-Beta2",
     "org.jetbrains.kotlinx:kover-cli": "0.8.0-Beta2",
     "org.jacoco:org.jacoco.agent": "0.8.12",
+    "org.jacoco:org.jacoco.cli": "0.8.12",
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.85",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -329,6 +329,7 @@ artifacts = {
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": "1.6.2",
     "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm": "1.6.2",
     "org.jetbrains.kotlinx:kover-jvm-agent": "0.8.0-Beta2",
+    "org.jetbrains.kotlinx:kover-cli": "0.8.0-Beta2",
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.85",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -328,9 +328,10 @@ artifacts = {
     "org.jetbrains.kotlinx:kotlinx-coroutines-test": "1.7.3",
     "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm": "1.6.2",
     "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm": "1.6.2",
-    "org.jetbrains.kotlinx:kover-jvm-agent": "0.8.0-Beta2",
-    "org.jetbrains.kotlinx:kover-cli": "0.8.0-Beta2",
-    "org.jacoco:org.jacoco.agent": "0.8.12",
+    "org.jacoco:org.jacoco.agent": {
+        "classifier": "runtime",
+        "version": "0.8.12",
+    },
     "org.jacoco:org.jacoco.cli": "0.8.12",
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -330,6 +330,7 @@ artifacts = {
     "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm": "1.6.2",
     "org.jetbrains.kotlinx:kover-jvm-agent": "0.8.0-Beta2",
     "org.jetbrains.kotlinx:kover-cli": "0.8.0-Beta2",
+    "org.jacoco:org.jacoco.agent": "0.8.12",
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.85",

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -332,7 +332,10 @@ artifacts = {
         "classifier": "runtime",
         "version": "0.8.12",
     },
-    "org.jacoco:org.jacoco.cli": "0.8.12",
+    "org.jacoco:org.jacoco.cli": {
+        "classifier": "nodeps",
+        "version": "0.8.12",
+    },
     # Find out the Skiko version we need by viewing dependencies of org.jetbrains.compose.ui/ui-graphics-desktop
     "org.jetbrains.skiko:skiko-awt": "0.7.85",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64": "0.7.85",

--- a/tool/sonarcloud/BUILD
+++ b/tool/sonarcloud/BUILD
@@ -10,7 +10,11 @@ py_binary(
     name = "code-analysis",
     srcs = ["code-analysis.py"],
     main = "code-analysis.py",
-    data = [ "@sonarscanner_zip//file"]
+    data = select({
+        "@vaticle_bazel_distribution//platform:is_linux":[ "@sonarscanner_linux_zip//file" ],
+        "@vaticle_bazel_distribution//platform:is_mac":[ "@sonarscanner_mac_zip//file" ],
+        "//conditions:default":[ "@sonarscanner_zip//file"]
+    })
 )
 
 checkstyle_test(

--- a/tool/sonarcloud/BUILD
+++ b/tool/sonarcloud/BUILD
@@ -10,11 +10,7 @@ py_binary(
     name = "code-analysis",
     srcs = ["code-analysis.py"],
     main = "code-analysis.py",
-    data = select({
-        "@vaticle_bazel_distribution//platform:is_linux":[ "@sonarscanner_linux_zip//file" ],
-        "@vaticle_bazel_distribution//platform:is_mac":[ "@sonarscanner_mac_zip//file" ],
-        "//conditions:default":[ "@sonarscanner_zip//file"]
-    })
+    data = [ "@sonarscanner_zip//file"]
 )
 
 checkstyle_test(

--- a/tool/sonarcloud/BUILD
+++ b/tool/sonarcloud/BUILD
@@ -10,7 +10,11 @@ py_binary(
     name = "code-analysis",
     srcs = ["code-analysis.py"],
     main = "code-analysis.py",
-    data = [ "@sonarscanner_zip//file" ]
+    data = select({
+        "@vaticle_bazel_distribution//platform:is_linux" : [ "@sonarscanner_linux_zip//file" ],
+        "@vaticle_bazel_distribution//platform:is_mac" : [ "@sonarscanner_mac_zip//file" ],
+        "//conditions:default" : [ "@sonarscanner_zip//file" ]
+    })
 )
 
 checkstyle_test(

--- a/tool/sonarcloud/BUILD
+++ b/tool/sonarcloud/BUILD
@@ -10,7 +10,7 @@ py_binary(
     name = "code-analysis",
     srcs = ["code-analysis.py"],
     main = "code-analysis.py",
-    data = [ "@sonarscanner_zip//file"]
+    data = [ "@sonarscanner_zip//file" ]
 )
 
 checkstyle_test(

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -27,7 +27,7 @@ tmpdir = None
 try:
     tmpdir = tempfile.mkdtemp()
     sp.check_call(['unzip', '-qq',
-        os.path.join('external', 'sonarscanner_zip', 'file', 'downloaded'), '-d', tmpdir])
+        os.path.join(glob.glob(os.path.join('external', 'sonarscanner_*_zip'))[0], 'file', 'downloaded'), '-d', tmpdir])
     sp.check_call(['mv'] + glob.glob(os.path.join(tmpdir, 'sonar-scanner-*', '*')) + ['.'], cwd=tmpdir)
     cmd=os.path.join(tmpdir, 'bin', 'sonar-scanner') + \
         ' -Dsonar.projectKey=' + args.project_key + \

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -36,11 +36,11 @@ try:
         ' -Dsonar.branch.name=' + args.branch + \
         ' -Dsonar.sources=. -Dsonar.java.binaries=. ' + \
         ' -Dsonar.java.libraries=.' + \
+        ' -Dsonar.plugins.downloadOnlyRequired=true' + \
         ' -Dsonar.host.url=https://sonarcloud.io' + \
         ' -Dsonar.token=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL'
     if args.coverage_reports is not None:
         cmd = cmd + ' -Dsonar.coverage.jacoco.xmlReportPaths=' + args.coverage_reports
-    print(cmd)
     sp.check_call(cmd, cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), shell=True)
 finally:
     shutil.rmtree(tmpdir)

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -20,8 +20,7 @@ parser.add_argument('--project-key', help='Sonarcloud project key', required=Tru
 parser.add_argument('--organisation', help='Sonarcloud organisation', default='vaticle')
 parser.add_argument('--commit-id', help='git commit id', required=True)
 parser.add_argument('--branch', help='git branch name', required=True)
-parser.add_argument('--coverage-reports', help='location of JaCoCo XML coverage reports', required=True)
-parser.add_argument('--host-url', help='Sonar URL', default='https://sonarcloud.io')
+parser.add_argument('--coverage-reports', help='location of JaCoCo XML coverage reports')
 args = parser.parse_args()
 
 tmpdir = None
@@ -30,17 +29,18 @@ try:
     sp.check_call(['unzip', '-qq',
         os.path.join('external', 'sonarscanner_zip', 'file', 'downloaded'), '-d', tmpdir])
     sp.check_call(['mv'] + glob.glob(os.path.join(tmpdir, 'sonar-scanner-*', '*')) + ['.'], cwd=tmpdir)
-    sp.check_call(
-        os.path.join(tmpdir, 'bin', 'sonar-scanner') + \
-            ' -Dsonar.projectKey=' + args.project_key + \
-            ' -Dsonar.organization=' + args.organisation + \
-            ' -Dsonar.projectVersion=' + args.commit_id + \
-            ' -Dsonar.branch.name=' + args.branch + \
-            ' -Dsonar.sources=. -Dsonar.java.binaries=. ' + \
-            ' -Dsonar.java.libraries=.' + \
-            ' -Dsonar.host.url=' + args.host_url + \
-            ' -Dsonar.coverage.jacoco.xmlReportPaths=' + args.coverage_reports + \
-            ' -Dsonar.token=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL',
-        cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), shell=True)
+    cmd=os.path.join(tmpdir, 'bin', 'sonar-scanner') + \
+        ' -Dsonar.projectKey=' + args.project_key + \
+        ' -Dsonar.organization=' + args.organisation + \
+        ' -Dsonar.projectVersion=' + args.commit_id + \
+        ' -Dsonar.branch.name=' + args.branch + \
+        ' -Dsonar.sources=. -Dsonar.java.binaries=. ' + \
+        ' -Dsonar.java.libraries=.' + \
+        ' -Dsonar.host.url=https://sonarcloud.io' + \
+        ' -Dsonar.token=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL'
+    if args.coverage_report is not None:
+        cmd = cmd + ' -Dsonar.coverage.jacoco.xmlReportPaths=' + args.coverage_reports
+    print(cmd)
+    sp.check_call(cmd, cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), shell=True)
 finally:
     shutil.rmtree(tmpdir)

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -26,8 +26,10 @@ args = parser.parse_args()
 tmpdir = None
 try:
     tmpdir = tempfile.mkdtemp()
-    sp.check_call(['unzip', '-qq',
-        os.path.join(glob.glob(os.path.join('external', 'sonarscanner_*_zip'))[0], 'file', 'downloaded'), '-d', tmpdir])
+    sonarscanner_path = glob.glob(os.path.join('external', 'sonarscanner_*_zip'))[0]
+    sp.check_call([
+        'unzip', '-qq', os.path.join(sonarscanner_path, 'file', 'downloaded'), '-d', tmpdir
+    ])
     sp.check_call(['mv'] + glob.glob(os.path.join(tmpdir, 'sonar-scanner-*', '*')) + ['.'], cwd=tmpdir)
     cmd=os.path.join(tmpdir, 'bin', 'sonar-scanner') + \
         ' -Dsonar.projectKey=' + args.project_key + \

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -38,7 +38,7 @@ try:
         ' -Dsonar.java.libraries=.' + \
         ' -Dsonar.host.url=https://sonarcloud.io' + \
         ' -Dsonar.token=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL'
-    if args.coverage_report is not None:
+    if args.coverage_reports is not None:
         cmd = cmd + ' -Dsonar.coverage.jacoco.xmlReportPaths=' + args.coverage_reports
     print(cmd)
     sp.check_call(cmd, cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), shell=True)

--- a/tool/sonarcloud/code-analysis.py
+++ b/tool/sonarcloud/code-analysis.py
@@ -20,6 +20,8 @@ parser.add_argument('--project-key', help='Sonarcloud project key', required=Tru
 parser.add_argument('--organisation', help='Sonarcloud organisation', default='vaticle')
 parser.add_argument('--commit-id', help='git commit id', required=True)
 parser.add_argument('--branch', help='git branch name', required=True)
+parser.add_argument('--coverage-reports', help='location of JaCoCo XML coverage reports', required=True)
+parser.add_argument('--host-url', help='Sonar URL', default='https://sonarcloud.io')
 args = parser.parse_args()
 
 tmpdir = None
@@ -36,8 +38,9 @@ try:
             ' -Dsonar.branch.name=' + args.branch + \
             ' -Dsonar.sources=. -Dsonar.java.binaries=. ' + \
             ' -Dsonar.java.libraries=.' + \
-            ' -Dsonar.host.url=https://sonarcloud.io' + \
-            ' -Dsonar.login=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL',
+            ' -Dsonar.host.url=' + args.host_url + \
+            ' -Dsonar.coverage.jacoco.xmlReportPaths=' + args.coverage_reports + \
+            ' -Dsonar.token=$SONARCLOUD_CODE_ANALYSIS_CREDENTIAL',
         cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), shell=True)
 finally:
     shutil.rmtree(tmpdir)

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -7,7 +7,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def sonarcloud_dependencies():
     select({
-        "@vaticle_bazel_distribution//platform:is_mac":http_file(
+        "@vaticle_bazel_distribution//platform:is_mac_arm64":http_file(
+            name = "sonarscanner_zip",
+            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
+        ),
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64":http_file(
             name = "sonarscanner_zip",
             urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
         ),

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -12,7 +12,7 @@ def sonarcloud_dependencies():
             urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
         ),
         "@vaticle_bazel_distribution//platform:is_linux":http_file(
-            name = "sonarscanner_linux_zip",
+            name = "sonarscanner_zip",
             urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip"]
         ),
         "//conditions:default": http_file(

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -8,5 +8,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sonarcloud_dependencies():
     http_file(
         name = "sonarscanner_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.0.2966/sonar-scanner-cli-5.0.0.2966.zip"]
     )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -8,5 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sonarcloud_dependencies():
     http_file(
         name = "sonarscanner_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/4.8.1.3023/sonar-scanner-cli-4.8.1.3023.zip"]
+        urls = [select({
+            "@vaticle_bazel_distribution//platform:is_mac" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip",
+            "@vaticle_bazel_distribution//platform:is_linux" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip",
+            "//conditions:default" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"
+        })]
     )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -8,9 +8,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sonarcloud_dependencies():
     http_file(
         name = "sonarscanner_zip",
-        urls = [select({
-            "@vaticle_bazel_distribution//platform:is_mac" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip",
-            "@vaticle_bazel_distribution//platform:is_linux" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip",
-            "//conditions:default" : "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"
-        })]
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
+    )
+    http_file(
+        name = "sonarscanner_mac_zip",
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
+    )
+    http_file(
+        name = "sonarscanner_linux_zip",
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip"]
     )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -8,5 +8,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sonarcloud_dependencies():
     http_file(
         name = "sonarscanner_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/3.3.0.1492/sonar-scanner-cli-3.3.0.1492.zip"]
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
     )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -8,5 +8,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def sonarcloud_dependencies():
     http_file(
         name = "sonarscanner_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.0.2966/sonar-scanner-cli-5.0.0.2966.zip"]
+        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/4.8.1.3023/sonar-scanner-cli-4.8.1.3023.zip"]
     )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -6,21 +6,17 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def sonarcloud_dependencies():
-    select({
-        "@vaticle_bazel_distribution//platform:is_mac_arm64":http_file(
-            name = "sonarscanner_zip",
-            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
-        ),
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64":http_file(
-            name = "sonarscanner_zip",
-            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
-        ),
-        "@vaticle_bazel_distribution//platform:is_linux":http_file(
-            name = "sonarscanner_zip",
-            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip"]
-        ),
-        "//conditions:default": http_file(
-            name = "sonarscanner_zip",
-            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-mac.zip"]
-        ),
-    })
+    http_file(
+        name = "sonarscanner_any_zip",
+        url = "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"
+    )
+
+    http_file(
+        name = "sonarscanner_mac_zip",
+        url = "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip",
+    )
+
+    http_file(
+        name = "sonarscanner_linux_zip",
+        url = "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip",
+    )

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -6,15 +6,17 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def sonarcloud_dependencies():
-    http_file(
-        name = "sonarscanner_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
-    )
-    http_file(
-        name = "sonarscanner_mac_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
-    )
-    http_file(
-        name = "sonarscanner_linux_zip",
-        urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip"]
-    )
+    select({
+        "@vaticle_bazel_distribution//platform:is_mac":http_file(
+            name = "sonarscanner_zip",
+            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-macosx.zip"]
+        ),
+        "@vaticle_bazel_distribution//platform:is_linux":http_file(
+            name = "sonarscanner_linux_zip",
+            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-linux.zip"]
+        ),
+        "//conditions:default": http_file(
+            name = "sonarscanner_zip",
+            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
+        ),
+    })

--- a/tool/sonarcloud/deps.bzl
+++ b/tool/sonarcloud/deps.bzl
@@ -21,6 +21,6 @@ def sonarcloud_dependencies():
         ),
         "//conditions:default": http_file(
             name = "sonarscanner_zip",
-            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006.zip"]
+            urls = ["https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/5.0.1.3006/sonar-scanner-cli-5.0.1.3006-mac.zip"]
         ),
     })


### PR DESCRIPTION
## What is the goal of this PR?

Introduce JaCoCo dependencies and improve the operation of the sonar code analysis tool

## What are the changes implemented in this PR?

We add the required dependencies, and modify the sonar code analysis tool to:
- use `sonar.token` instead of `sonar.login`
- accept an optional `--coverage-reports` parameter for JaCoCo XML coverage reports
- only download required plugins
- Use the mac and linux platform-specific CLI tool where possible, which comes with a packaged JRE, allowing it to run correctly on machines that don't have the required Java 17
