### PR TITLE
Bump snake-yaml maven dependency to 2.2

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -360,7 +360,7 @@ artifacts = {
     "org.slf4j:slf4j-api": "2.0.0",
     "org.slf4j:slf4j-simple": "2.0.0",
     "org.springframework.security:spring-security-crypto": "5.5.0",
-    "org.yaml:snakeyaml": "1.25",
+    "org.yaml:snakeyaml": "2.2",
     "org.zeromq:jeromq": "0.5.2",
     "org.zeroturnaround:zt-exec": "1.10",
     "com.mailgun:mailgun-java": "1.1.2",


### PR DESCRIPTION
## What is the goal of this PR?
Bump our maven dependency on snake-yaml to 2.2

## What are the changes implemented in this PR?
Updates snake-yaml to 2.2. 
TypeDB's ConfigParserTest was confirmed to pass with no changes needed.