### PR TITLE
Bump rules_python to 0.31.0

### DIFF
--- a/builder/python/deps.bzl
+++ b/builder/python/deps.bzl
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def deps(use_patched_version=False):
     http_archive(
         name = "rules_python",
-        sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
-        strip_prefix = "rules_python-0.24.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
+        sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
+        strip_prefix = "rules_python-0.31.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
     )

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "5e64e336c9bd0965e654d7fca19fa9bd2a55b01a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        remote = "https://github.com/vaticle/bazel-distribution",
+        commit = "0040e492db47eb83681a62ddf8491a7218633164" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "425493c9a92ef894b99b3b8071886dd2af8098cf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        remote = "https://github.com/krishnangovindraj/bazel-distribution",
+        commit = "a9837fc7e68ee15261312f7635f6764f728a326b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )

--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -9,5 +9,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "a9837fc7e68ee15261312f7635f6764f728a326b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "5e64e336c9bd0965e654d7fca19fa9bd2a55b01a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?
Bump rules_python to fix windows error on sync.

## What are the changes implemented in this PR?
rules_python 0.24.0 was breaking with the error: `module 'pkgutil' has no attribute 'ImpImporter'`. This was fixed by version 0.26.0 (?). We bump the dependency further to 0.31.0