### PR TITLE
Bump aspect_rules_ts to v2.4.0

### DIFF
--- a/builder/nodejs/deps.bzl
+++ b/builder/nodejs/deps.bzl
@@ -14,7 +14,7 @@ def deps(patch = []):
 
     http_archive(
         name = "aspect_rules_ts",
-        sha256 = "4c3f34fff9f96ffc9c26635d8235a32a23a6797324486c7d23c1dfa477e8b451",
-        strip_prefix = "rules_ts-1.4.5",
-        url = "https://github.com/aspect-build/rules_ts/releases/download/v1.4.5/rules_ts-v1.4.5.tar.gz",
+        sha256 = "97a8246bf6d1c7077b296e90a6e307bf8eabed02c5bca84d46db81efbf6ead41",
+        strip_prefix = "rules_ts-2.4.0",
+        url = "https://github.com/aspect-build/rules_ts/releases/download/v2.4.0/rules_ts-v2.4.0.tar.gz",
     )


### PR DESCRIPTION
## What is the goal of this PR?

Bump aspect_rules_ts to v2.4.0.

## What are the changes implemented in this PR?

TypeDB Platform uses TypeScript 5.2.2. This is required because Angular 17 only supports TypeScript above version 5.2. But `aspect_rules_ts` on the old version (1.45) only supports TypeScript up to 5.1.6.

This change may potentially break Bazel builds of the NodeJS driver (untested). This could occur if symbols (e.g. rules) exposed by `aspect_rules_ts` and used by the NodeJS driver have been functionally changed, renamed, or deleted.