### PR TITLE
Add mockito-kotlin dependency

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -354,6 +354,7 @@ artifacts = {
     "org.jsoup:jsoup": "1.16.1",
     "org.kohsuke:github-api": "1.101",
     "org.mockito:mockito-core": "3.2.4",
+    "org.mockito.kotlin:mockito-kotlin": "3.0.0",
     "org.openjdk.jmh:jmh-core": "1.23",
     "org.openjdk.jmh:jmh-generator-annprocess": "1.23",
     "org.scala-lang:scala-library": "2.12.10",


### PR DESCRIPTION
## What is the goal of this PR?

We add a [mockito-kotlin](https://mvnrepository.com/artifact/org.mockito.kotlin/mockito-kotlin/3.0.0) dependency suitable for our `Java` version to have more flexible mocks in `Kotlin` tests, including concurrent functions' mocks for `typedb-diagnostics`.

## What are the changes implemented in this PR?

We add a `mockito-kotlin` library dependency.
