### PR TITLE
Add integration tests to generated Cargo.toml

### DIFF
--- a/builder/rust/cargo/project_aspect.bzl
+++ b/builder/rust/cargo/project_aspect.bzl
@@ -205,6 +205,9 @@ def _get_properties(target, ctx, source_files, crate_info):
         properties["entry.point.path"] = _src_relpath(target, ctx, entry_point_file)
         if len(_crate_build_deps_info(crate_info)) > 0:
             fail("Build deps support unimplemented")
+    if target_type == "test" and ctx.rule.attr.crate == None:
+       entry_point_file = _entry_point_file(target, ctx, source_files)
+       properties["entry.point.path"] = _src_relpath(target, ctx, entry_point_file)
     for dep in _crate_deps_info(target, crate_info).items():
         properties["deps." + dep[0]] = dep[1]
     return properties
@@ -256,6 +259,9 @@ def _entry_point_file(target, ctx, source_files):
         return _find_entry_point_in_sources(target, ctx, source_files)
 
 def _find_entry_point_in_sources(target, ctx, source_files):
+    if len(source_files) == 1:
+        return source_files[0]
+
     standard_entry_point_name = _BIN_ENTRY_POINT if ctx.rule.kind == "rust_binary" else _LIB_ENTRY_POINT
     alternative_entry_point_name = "{}.rs".format(ctx.rule.attr.name)
 

--- a/tool/ide/RustManifestSyncer.kt
+++ b/tool/ide/RustManifestSyncer.kt
@@ -327,13 +327,18 @@ class RustManifestSyncer : Callable<Unit> {
             }
 
             private fun Config.addTests() {
-                if (properties.tests.isNotEmpty()) {
-                    val mapped = properties.tests.map {
+                val mapped = properties.tests.map {
+                    if (it.entryPointPath != null) {
+                        val path = Path(properties.cratePath).relativize(Path(it.cratePath)).resolve(it.entryPointPath)
                         createSubConfig().apply {
                             this.set<String>("name", it.name)
-                            this.set<String>("path", Path(properties.cratePath).relativize(Path(it.cratePath)).toString());
+                            this.set<String>("path", path.toString());
                         }
+                    } else {
+                        null
                     }
+                }.filterNotNull()
+                if (mapped.isNotEmpty()) {
                     this.set<List<Config>>("test", mapped)
                 }
             }

--- a/tool/ide/RustManifestSyncer.kt
+++ b/tool/ide/RustManifestSyncer.kt
@@ -142,6 +142,7 @@ class RustManifestSyncer : Callable<Unit> {
             val subConfig = cargoToml.createSubConfig()
             subConfig.set<List<String>>("members", manifestPaths)
             cargoToml.set<Config>("workspace", subConfig)
+            cargoToml.set<String>("resolver", "2")
             return cargoToml
         }
 
@@ -238,6 +239,7 @@ class RustManifestSyncer : Callable<Unit> {
 
                 cargoToml.addDevAndBuildDependencies()
                 cargoToml.addBenches()
+                cargoToml.addTests()
 
                 return GENERATED_FILE_NOTICE + TomlWriter().writeToString(cargoToml.unmodifiable())
             }
@@ -321,6 +323,18 @@ class RustManifestSyncer : Callable<Unit> {
                         }
                     }
                     this.set<List<Config>>("bench", mapped)
+                }
+            }
+
+            private fun Config.addTests() {
+                if (properties.tests.isNotEmpty()) {
+                    val mapped = properties.tests.map {
+                        createSubConfig().apply {
+                            this.set<String>("name", it.name)
+                            this.set<String>("path", Path(properties.cratePath).relativize(Path(it.cratePath)).toString());
+                        }
+                    }
+                    this.set<List<Config>>("test", mapped)
                 }
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

We now generate a `Cargo.toml` entry per Bazel `rust_test` entry, if that test is a module/crate on its own and not a set of unit tests, that apply for a specific existing crate (eg. using the `crate = ":target"` attribute).

We support the conversion of Bazel Rust integration test targets when there is exactly 1 source file in the `rust_test` target. Otherwise, we expect that the `crate_root` be set to the source file that contains the test targets.

For example:
```
rust_test(
  name = "test_abc",
  srcs = ["test_abc_v_1.rs, "common/utils.rs"]
)
```
is now considered ambiguous, and must be updated to:
```
rust_test(
  name = "test_abc",
  crate_root = "test_abc_v_1.rs",
  srcs = ["test_abc_v_1.rs, "common/utils.rs"]
)
```

Unrelatedly, we add `resolver = "2"` for into the root `Cargo.toml`, whenever we need to generate a Cargo workspace.

## What are the changes implemented in this PR?

* The rust project aspect now generates an `entry_point_path` property for test targets, as well as binaries and libraries, if the test is a integration test (eg no `crate = :target` set).
* The cargo toml generator adds test entries as well a benchmark entries for integration tests in the crate/package